### PR TITLE
History + Diff JSON + regml.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: python
 sudo: false
 python: 3.4
 env:
-    - TOX_ENV=py34
     - TOX_ENV=py27
-    - TOX_ENV=flake8
 install:
     - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -8,3 +8,65 @@ Parse [regulation XML](https://github.com/cfpb/regulations-schema) to
 generate JSON for [regulations-core[(https://github.com/cfpb/regulations-core) 
 to serve to [regulations-site](https://github.com/cfpb/regulations-site).
 
+
+## Usage
+
+There are two types of RegML files:
+
+- `regulation` files which contain the full text of a regulation version
+- `notice` files which contain the changes necessary to transform the
+  preceding version of a regulation into the next version
+
+### Generating RegML from eCFR
+
+To generate RegML from an eCFR XML file using 
+ [regulations-parser](https://github.com/cfpb/regulations-parser):
+
+```shell
+./regml.py ecfr 12 [eCFR File]
+```
+
+This will generate the RegML `regulation` tree for the initial version
+and RegML `notice` trees with the necessary changeset for each
+subsequent version.
+
+If you want only want to output RegML for a single notice:
+
+```shell
+./regml.py ecfr 12 [eCFR File] --only-notice [notice number]
+```
+
+## Generating RegML from `regulation` + `notice`
+
+
+To apply a `notice` file to a `regulation` file:
+
+```shell
+./regml.py apply [RegML regulation file] [RegML notice file]
+```
+
+This will create a new RegML file with the notice file's changes applied
+to the given regulation file.
+
+## Validating RegML
+
+To validate a RegML file against
+[regulations-schema](https://github.com/cfpb/regulations-schema):
+
+```shell
+./regml.py validate [RegML regulation or notice file]
+```
+
+## Generating JSON from RegML
+
+To generate JSON from RegML for use with
+[regulations-core](https://github.com/cfpb/regulations-core):
+
+```shell
+./regml.py json [RegML regulation file] []RegML regulation file] ...
+```
+
+If more than one RegML file is given, the JSON files that are created
+will include diff files that contain the changes between each version
+provided.
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ To apply a `notice` file to a `regulation` file:
 This will create a new RegML file with the notice file's changes applied
 to the given regulation file.
 
+The path to the RegML files can be relative to the `XML_ROOT` in your
+`settings.py` file. For example, if you have the RegML files in
+`../../regulations-stub/xml` and your 
+`XML_ROOT="../../regulations-stub/xml"`, you can use:
+
+```
+./regml.py apply 1111/1234-56789.xml 1111/1234-67890.xml
+```
+
 ## Validating RegML
 
 To validate a RegML file against
@@ -70,3 +79,20 @@ If more than one RegML file is given, the JSON files that are created
 will include diff files that contain the changes between each version
 provided.
 
+As with the other RegML commands above, the path to the RegML files 
+can be relative to the `XML_ROOT` in your `settings.py` file. 
+For example, if you have the RegML files in
+`../../regulations-stub/xml` and your 
+`XML_ROOT="../../regulations-stub/xml"`, you can use:
+
+```
+./regml.py json 1111/1234-56789.xml
+```
+
+Additionally, to generate JSON for all RegML files in a particular
+regulation's directory in the `XML_ROOT`, you can simple use the
+regulation directory name (usually the part number):
+
+```
+./regml.py json 1111
+```

--- a/regml.py
+++ b/regml.py
@@ -5,7 +5,6 @@
 from __future__ import print_function
 
 import json
-import logging
 import os
 import sys
 

--- a/regml.py
+++ b/regml.py
@@ -37,13 +37,9 @@ from regparser.federalregister import fetch_notice_json
 from regparser.builder import Builder, LayerCacheAggregator, tree_and_builder
 from regparser.notice.build import check_local_version_list
 
-
 if (sys.version_info < (3, 0)):
     reload(sys)  # noqa
     sys.setdefaultencoding('UTF8')
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 # Utility Functions ####################################################
 
@@ -94,13 +90,80 @@ def write_layer(layer_object, reg_number, notice, layer_type,
     if diff_notice is not None:
         layer_path = os.path.join(layer_path, diff_notice)
     if not os.path.exists(layer_path):
-        os.mkdir(layer_path)
+        os.makedirs(layer_path)
     layer_file = os.path.join(layer_path, notice)
-    logger.info("writing", layer_file)
+    print("writing", layer_file)
     json.dump(layer_object, open(layer_file, 'w'), indent=4,
               separators=(',', ':'))
 
+def generate_json(regulation_file, check_terms=False):
+    with open(find_file(regulation_file), 'r') as f:
+        reg_xml = f.read()
+    xml_tree = etree.fromstring(reg_xml)
 
+    # validate relative to schema
+    validator = EregsValidator(settings.XSD_FILE)
+    validator.validate_reg(xml_tree)
+
+    if not validator.is_valid:
+        for event in validator.events:
+            print(str(event))
+        sys.exit(0)
+
+    reg_tree = build_reg_tree(xml_tree)
+    reg_number = reg_tree.label[0]
+
+    paragraph_markers = build_paragraph_marker_layer(xml_tree)
+    internal_citations = build_internal_citations_layer(xml_tree)
+    external_citations = build_external_citations_layer(xml_tree)
+    terms = build_terms_layer(xml_tree)
+    meta = build_meta_layer(xml_tree)
+    toc = build_toc_layer(xml_tree)
+    keyterms = build_keyterm_layer(xml_tree)
+    graphics = build_graphics_layer(xml_tree)
+    formatting = build_formatting_layer(xml_tree)
+    interps = build_interp_layer(xml_tree)
+    analysis = build_analysis(xml_tree)
+    notice_dict = build_notice(xml_tree)
+
+    # if the validator had problems then we should report them and bail out
+
+    validator.validate_terms(xml_tree, terms)
+    validator.validate_internal_cites(xml_tree, internal_citations)
+    if check_terms:
+        validator.validate_term_references(xml_tree, terms, regulation_file)
+    for event in validator.events:
+        print(str(event))
+
+    reg_tree.include_children = True
+    reg_json = reg_tree.to_json()
+
+    notice = xml_tree.find('.//{eregs}documentNumber').text
+    version = os.path.split(regulation_file)[-1].replace('.xml', '')
+    if notice != version:
+        print('Notice ({}) different from version ({}), using version'.format(notice, version))
+        notice = version
+
+    write_layer(reg_json, reg_number, notice, 'regulation')
+    write_layer(meta, reg_number, notice, 'layer/meta')
+    write_layer(paragraph_markers, reg_number, notice,
+                'layer/paragraph-markers')
+    write_layer(internal_citations, reg_number, notice,
+                'layer/internal-citations')
+    write_layer(external_citations, reg_number, notice,
+                'layer/external-citations')
+    write_layer(terms, reg_number, notice, 'layer/terms')
+    write_layer(toc, reg_number, notice, 'layer/toc')
+    write_layer(keyterms, reg_number, notice, 'layer/keyterms')
+    write_layer(graphics, reg_number, notice, 'layer/graphics')
+    write_layer(formatting, reg_number, notice, 'layer/formatting')
+    write_layer(interps, reg_number, notice, 'layer/interpretations')
+    write_layer(analysis, reg_number, notice, 'layer/analyses')
+    write_layer(notice_dict, reg_number, notice, 'notice')
+
+    return reg_number, notice, xml_tree
+
+       
 # Main CLI Commands ####################################################
 
 # Create a general CLI that can take additional comments
@@ -126,7 +189,7 @@ def validate(check_terms, file):
 
     if not validator.is_valid:
         for event in validator.events:
-            logger.error(str(event))
+            print(str(event))
         sys.exit(0)
 
     # Validate regulation-specific documents
@@ -140,7 +203,7 @@ def validate(check_terms, file):
         if check_terms:
             validator.validate_term_references(xml_tree, terms, file)
         for event in validator.events:
-            logger.warning(str(event))
+            print(str(event))
 
     # Validate notice-specific documents
     if xml_tree.tag == '{eregs}notice':
@@ -156,86 +219,25 @@ def validate(check_terms, file):
 # diff JSON will be generated between them.
 @cli.command('json')
 @click.argument('regulation_files', nargs=-1)
-@click.option('--check-terms', default=False)
-def generate_json(regulation_files, check_terms):
+@click.option('--check-terms', is_flag=True)
+def json_command(regulation_files, check_terms=False):
     """ Generate JSON from RegML files """
 
-    # If we've got a list of files, recurse through them one at a time
-    # to build each individual version, then generate diffs for all
-    # versions.
-    if len(regulation_files) > 1:
-        # Generate JSON for each version
-        versions = {}
-        reg_number = None
-        for file in regulation_files:
-            reg_number, notice, reg_xml_tree = generate_json(file, 
-                                                             check_terms)
-            versions[notice] = reg_xml_tree
+    # Generate JSON for each version
+    versions = {}
+    reg_number = None
+    for file in regulation_files:
+        reg_number, notice, reg_xml_tree = generate_json(file,
+            check_terms=check_terms)
+        versions[notice] = reg_xml_tree
 
-        # Generate diff JSON between each version
-        # now build diffs - include "empty" diffs comparing a version to itself
-        for left_version, left_tree in versions.items():
-            for right_version, right_tree in versions.items():
-                diff = generate_diff(left_tree, right_tree)
-                write_layer(diff, reg_number, left_version, 'diff',
-                        diff_notice=right_version)
-
-        return ()
-
-    # Otherwise if we got one file, generate the JSON for it.
-    with open(find_file(regulation_files[0]), 'r') as f:
-        reg_xml = f.read()
-    xml_tree = etree.fromstring(reg_xml)
-
-    # Validate the file relative to schema
-    validator = EregsValidator(settings.XSD_FILE)
-    validator.validate_reg(xml_tree)
-
-    if not validator.is_valid:
-        for event in validator.events:
-            logger.error(str(event))
-        sys.exit(0)
-
-    reg_tree = build_reg_tree(xml_tree)
-    reg_number = reg_tree.label[0]
-
-    paragraph_markers = build_paragraph_marker_layer(xml_tree)
-    internal_citations = build_internal_citations_layer(xml_tree)
-    external_citations = build_external_citations_layer(xml_tree)
-    terms = build_terms_layer(xml_tree)
-    meta = build_meta_layer(xml_tree)
-    toc = build_toc_layer(xml_tree)
-    keyterms = build_keyterm_layer(xml_tree)
-    graphics = build_graphics_layer(xml_tree)
-    formatting = build_formatting_layer(xml_tree)
-    interps = build_interp_layer(xml_tree)
-    analysis = build_analysis(xml_tree)
-    notice_dict = build_notice(xml_tree)
-
-    reg_tree.include_children = True
-    reg_json = reg_tree.to_json()
-
-    notice = xml_tree.find('{eregs}preamble/{eregs}documentNumber').text
-
-    write_layer(reg_json, reg_number, notice, 'regulation')
-    write_layer(meta, reg_number, notice, 'layer/meta')
-    write_layer(paragraph_markers, reg_number, notice,
-                'layer/paragraph-markers')
-    write_layer(internal_citations, reg_number, notice,
-                'layer/internal-citations')
-    write_layer(external_citations, reg_number, notice,
-                'layer/external-citations')
-    write_layer(terms, reg_number, notice, 'layer/terms')
-    write_layer(toc, reg_number, notice, 'layer/toc')
-    write_layer(keyterms, reg_number, notice, 'layer/keyterms')
-    write_layer(graphics, reg_number, notice, 'layer/graphics')
-    write_layer(formatting, reg_number, notice, 'layer/formatting')
-    write_layer(interps, reg_number, notice, 'layer/interpretations')
-    write_layer(analysis, reg_number, notice, 'layer/analyses')
-    write_layer(notice_dict, reg_number, notice, 'notice')
-
-    # Return the XML tree in case we're recursing.
-    return reg_number, notice, xml_tree
+    # Generate diff JSON between each version
+    # now build diffs - include "empty" diffs comparing a version to itself
+    for left_version, left_tree in versions.items():
+        for right_version, right_tree in versions.items():
+            diff = generate_diff(left_tree, right_tree)
+            write_layer(diff, reg_number, left_version, 'diff',
+                    diff_notice=right_version)
 
 
 # Given a notice, apply it to a previous RegML regulation verson to
@@ -269,7 +271,7 @@ def apply(regulation_file, notice_file):
         os.path.dirname(regulation_file),
         os.path.basename(notice_file))
     with open(new_path, 'w') as f:
-        logger.info("Writing regulation to {}".format(new_path))
+        print("Writing regulation to {}".format(new_path))
         f.write(new_xml_string)
 
  
@@ -312,7 +314,7 @@ def ecfr(title, file, act_title, act_section,
     layers = builder.generate_layers(reg_tree, [act_title, act_section], layer_cache)
 
     # Do the first version
-    logger.info("Version %s", builder.doc_number)
+    print("Version %s", builder.doc_number)
     if (only_notice is not None and builder.doc_number == only_notice) or \
             only_notice is None:
         if not without_versions:
@@ -321,7 +323,7 @@ def ecfr(title, file, act_title, act_section,
     for last_notice, old, new_tree, notices in builder.revision_generator(
             reg_tree):
         version = last_notice['document_number']
-        logger.info("Version %s", version)
+        print("Version %s", version)
         builder.doc_number = version
         layers = builder.generate_layers(new_tree, 
                                          [act_title, act_section],

--- a/regml.py
+++ b/regml.py
@@ -68,10 +68,10 @@ def find_file(file, is_notice=False, ecfr=False):
             else:
                 regml_base = os.path.join(regml_base, 'regulation')
 
-            if not file.endswith('.xml'):
-                file += '.xml'
-
             file = os.path.join(regml_base, file)
+
+            if not file.endswith('.xml') and not os.path.isdir(file):
+                file += '.xml'
 
     return file
 
@@ -217,10 +217,17 @@ def validate(check_terms, file):
 # If multiple RegML files are given, and belong to the same regulation,
 # diff JSON will be generated between them.
 @cli.command('json')
-@click.argument('regulation_files', nargs=-1)
+@click.argument('regulation_files', nargs=-1, required=True)
 @click.option('--check-terms', is_flag=True)
 def json_command(regulation_files, check_terms=False):
     """ Generate JSON from RegML files """
+
+    # If the "file" is a directory, assume we want to operate on all the
+    # files in that directory in listing order
+    if os.path.isdir(find_file(regulation_files[0])):
+        regulation_dir = find_file(regulation_files[0])
+        regulation_files = [os.path.join(regulation_dir, f) 
+                            for f in os.listdir(regulation_dir)]
 
     # Generate JSON for each version
     versions = {}

--- a/regml.py
+++ b/regml.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+"""
+
+"""
+from __future__ import print_function
+
+import json
+import logging
+import os
+import sys
+
+import click
+from termcolor import colored, cprint
+from lxml import etree
+
+from regulation.validation import EregsValidator
+import regulation.settings as settings
+
+from regulation.tree import (build_analysis,
+                             build_external_citations_layer,
+                             build_formatting_layer,
+                             build_graphics_layer,
+                             build_internal_citations_layer,
+                             build_interp_layer,
+                             build_keyterm_layer,
+                             build_meta_layer,
+                             build_notice,
+                             build_paragraph_marker_layer,
+                             build_reg_tree,
+                             build_terms_layer,
+                             build_toc_layer)
+from regulation.changes import process_changes, generate_diff
+
+# Import regparser here with the eventual goal of breaking off the parts
+# we're using in the RegML parser into a library both can share.
+from regparser.federalregister import fetch_notice_json
+from regparser.builder import Builder, LayerCacheAggregator, tree_and_builder
+from regparser.notice.build import check_local_version_list
+
+
+if (sys.version_info < (3, 0)):
+    reload(sys)  # noqa
+    sys.setdefaultencoding('UTF8')
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Utility Functions ####################################################
+
+def find_file(file, is_notice=False, ecfr=False):
+    """ 
+        Find the given file in sources available in configured
+        locations and read it. 
+        
+        For example, if we're looking for a RegML file for version 
+        2222-33333 with the default arguments, 
+        settings.XML_ROOT/regulation will be searched for a matching
+        document. 
+
+        With ecfr=True and regml=False, eCFR fr-notices
+        (settings.LOCAL_XML_PATHS) will be searched.
+    """
+    # See if we need to find this file somewhere
+    if not os.path.exists(file):
+        if ecfr:
+            ecfr_base = settings.LOCAL_XML_PATHS[0]
+            file = os.path.join(ecfr_base, file)
+        
+        else:
+            regml_base = settings.XML_ROOT
+            if is_notice:
+                regml_base = os.path.join(regml_base, 'notice')
+            else:
+                regml_base = os.path.join(regml_base, 'regulation')
+
+            if not file.endswith('.xml'):
+                file += '.xml'
+
+            file = os.path.join(regml_base, file)
+
+    return file
+
+
+def find_version(part, notice, is_notice=False):
+    """ Wrap find file in a semantic sort of way to find a RegML version 
+        of a particular part"""
+    return find_file(os.path.join(part, notice), is_notice=is_notice)
+
+
+def write_layer(layer_object, reg_number, notice, layer_type,
+        diff_notice=None):
+    """ Write a layer. """
+    layer_path = os.path.join(settings.JSON_ROOT, layer_type, reg_number)
+    if diff_notice is not None:
+        layer_path = os.path.join(layer_path, diff_notice)
+    if not os.path.exists(layer_path):
+        os.mkdir(layer_path)
+    layer_file = os.path.join(layer_path, notice)
+    logger.info("writing", layer_file)
+    json.dump(layer_object, open(layer_file, 'w'), indent=4,
+              separators=(',', ':'))
+
+
+# Main CLI Commands ####################################################
+
+# Create a general CLI that can take additional comments
+@click.group()
+def cli():
+    pass
+
+
+# Perform validation on the given RegML file without any additional
+# actions.
+@cli.command()
+@click.option('--check-terms', default=False)
+@click.argument('file')
+def validate(check_terms, file):
+    """ Validate a RegML file """
+    with open(find_file(file), 'r') as f:
+        reg_xml = f.read()
+    xml_tree = etree.fromstring(reg_xml)
+    
+    # Validate the file relative to schema
+    validator = EregsValidator(settings.XSD_FILE)
+    validator.validate_reg(xml_tree)
+
+    if not validator.is_valid:
+        for event in validator.events:
+            logger.error(str(event))
+        sys.exit(0)
+
+    # Validate regulation-specific documents
+    if xml_tree.tag == '{eregs}regulation':
+        terms = build_terms_layer(xml_tree)
+        internal_citations = build_internal_citations_layer(xml_tree)
+
+        validator.validate_terms(xml_tree, terms)
+        validator.validate_internal_cites(xml_tree, internal_citations)
+
+        if check_terms:
+            validator.validate_term_references(xml_tree, terms, file)
+        for event in validator.events:
+            logger.warning(str(event))
+
+    # Validate notice-specific documents
+    if xml_tree.tag == '{eregs}notice':
+        pass
+
+    return validator
+
+
+# Validate the given regulation file (or files) and generate the JSON
+# output expected by regulations-core and regulations-site if the RegML
+# validates.
+# If multiple RegML files are given, and belong to the same regulation,
+# diff JSON will be generated between them.
+@cli.command('json')
+@click.argument('regulation_files', nargs=-1)
+@click.option('--check-terms', default=False)
+def generate_json(regulation_files, check_terms):
+    """ Generate JSON from RegML files """
+
+    # If we've got a list of files, recurse through them one at a time
+    # to build each individual version, then generate diffs for all
+    # versions.
+    if len(regulation_files) > 1:
+        # Generate JSON for each version
+        versions = {}
+        reg_number = None
+        for file in regulation_files:
+            reg_number, notice, reg_xml_tree = generate_json(file, 
+                                                             check_terms)
+            versions[notice] = reg_xml_tree
+
+        # Generate diff JSON between each version
+        # now build diffs - include "empty" diffs comparing a version to itself
+        for left_version, left_tree in versions.items():
+            for right_version, right_tree in versions.items():
+                diff = generate_diff(left_tree, right_tree)
+                write_layer(diff, reg_number, left_version, 'diff',
+                        diff_notice=right_version)
+
+        return ()
+
+    # Otherwise if we got one file, generate the JSON for it.
+    with open(find_file(regulation_files[0]), 'r') as f:
+        reg_xml = f.read()
+    xml_tree = etree.fromstring(reg_xml)
+
+    # Validate the file relative to schema
+    validator = EregsValidator(settings.XSD_FILE)
+    validator.validate_reg(xml_tree)
+
+    if not validator.is_valid:
+        for event in validator.events:
+            logger.error(str(event))
+        sys.exit(0)
+
+    reg_tree = build_reg_tree(xml_tree)
+    reg_number = reg_tree.label[0]
+
+    paragraph_markers = build_paragraph_marker_layer(xml_tree)
+    internal_citations = build_internal_citations_layer(xml_tree)
+    external_citations = build_external_citations_layer(xml_tree)
+    terms = build_terms_layer(xml_tree)
+    meta = build_meta_layer(xml_tree)
+    toc = build_toc_layer(xml_tree)
+    keyterms = build_keyterm_layer(xml_tree)
+    graphics = build_graphics_layer(xml_tree)
+    formatting = build_formatting_layer(xml_tree)
+    interps = build_interp_layer(xml_tree)
+    analysis = build_analysis(xml_tree)
+    notice_dict = build_notice(xml_tree)
+
+    reg_tree.include_children = True
+    reg_json = reg_tree.to_json()
+
+    notice = xml_tree.find('{eregs}preamble/{eregs}documentNumber').text
+
+    write_layer(reg_json, reg_number, notice, 'regulation')
+    write_layer(meta, reg_number, notice, 'layer/meta')
+    write_layer(paragraph_markers, reg_number, notice,
+                'layer/paragraph-markers')
+    write_layer(internal_citations, reg_number, notice,
+                'layer/internal-citations')
+    write_layer(external_citations, reg_number, notice,
+                'layer/external-citations')
+    write_layer(terms, reg_number, notice, 'layer/terms')
+    write_layer(toc, reg_number, notice, 'layer/toc')
+    write_layer(keyterms, reg_number, notice, 'layer/keyterms')
+    write_layer(graphics, reg_number, notice, 'layer/graphics')
+    write_layer(formatting, reg_number, notice, 'layer/formatting')
+    write_layer(interps, reg_number, notice, 'layer/interpretations')
+    write_layer(analysis, reg_number, notice, 'layer/analyses')
+    write_layer(notice_dict, reg_number, notice, 'notice')
+
+    # Return the XML tree in case we're recursing.
+    return reg_number, notice, xml_tree
+
+
+# Given a notice, apply it to a previous RegML regulation verson to
+# generate a new version in RegML.
+@cli.command()
+@click.argument('regulation_file')
+@click.argument('notice_file')
+def apply(regulation_file, notice_file):
+    """ Apply notice changes """
+    # Read the RegML starting point
+    regulation_file = find_file(regulation_file)
+    with open(regulation_file, 'r') as f:
+        left_reg_xml = f.read()
+    left_xml_tree = etree.fromstring(left_reg_xml)
+
+    # Read the notice file
+    notice_file = find_file(notice_file, is_notice=True)
+    with open(notice_file, 'r') as f:
+        notice_string = f.read()
+    notice_xml = etree.fromstring(notice_string)
+
+    # Process the notice changeset
+    new_xml_tree = process_changes(left_xml_tree, notice_xml)
+
+    # Write the new xml tree
+    new_xml_string = etree.tostring(new_xml_tree, 
+                                    pretty_print=True,
+                                    xml_declaration=True, 
+                                    encoding='UTF-8')
+    new_path = os.path.join(
+        os.path.dirname(regulation_file),
+        os.path.basename(notice_file))
+    with open(new_path, 'w') as f:
+        logger.info("Writing regulation to {}".format(new_path))
+        f.write(new_xml_string)
+
+ 
+@cli.command()
+@click.argument('title')
+@click.argument('part')
+def noticelist(title, part):
+    """ List notices for regulation title/part """
+    notices = fetch_notice_json(title, part, only_final=True)
+    doc_numbers = [n['document_number'] for n in notices]
+    for number in doc_numbers:
+        print(number)
+
+
+# eCFR Convenience Commands ############################################
+
+# Wrap the eCFR parser as a library for the purposes of our workflow
+@cli.command()
+@click.argument('title', type=int)
+@click.argument('file')
+@click.option('--act-section', default=0, type=int)
+@click.option('--act-title', default=0, type=int)
+@click.option('--with-all-versions', is_flag=True,
+        help="do not output version reg trees")
+@click.option('--without-versions', is_flag=True,
+        help="do not output any version reg trees")
+@click.option('--without-notices', is_flag=True, 
+        help="do not output any notice changesets")
+@click.option('--only-notice', default=None,
+        help="only write output for this notice number")
+def ecfr(title, file, act_title, act_section, 
+        with_all_versions=False, without_versions=False, 
+        without_notices=False, only_notice=None):
+    """ Parse eCFR into RegML """
+
+    # Get the tree and layers
+    reg_tree, builder = tree_and_builder(
+            file, title, writer_type='XML')
+    layer_cache = LayerCacheAggregator()
+    layers = builder.generate_layers(reg_tree, [act_title, act_section], layer_cache)
+
+    # Do the first version
+    logger.info("Version %s", builder.doc_number)
+    if (only_notice is not None and builder.doc_number == only_notice) or \
+            only_notice is None:
+        if not without_versions:
+            builder.write_regulation(reg_tree, layers=layers)
+
+    for last_notice, old, new_tree, notices in builder.revision_generator(
+            reg_tree):
+        version = last_notice['document_number']
+        logger.info("Version %s", version)
+        builder.doc_number = version
+        layers = builder.generate_layers(new_tree, 
+                                         [act_title, act_section],
+                                         layer_cache, 
+                                         notices)
+        if (only_notice is not None and version == only_notice) or \
+                only_notice is None:
+            if with_all_versions:
+                builder.write_regulation(new_tree, layers=layers)
+            if not without_notices:
+                builder.write_notice(version, 
+                                     old_tree=old, 
+                                     reg_tree=new_tree,
+                                     layers=layers)
+        layer_cache.invalidate_by_notice(last_notice)
+        layer_cache.replace_using(new_tree)
+        del last_notice, old, new_tree, notices     # free some memory
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -5,9 +5,6 @@ from __future__ import unicode_literals
 from copy import deepcopy
 import itertools
 import logging
-import string
-
-from lxml import etree
 
 # Import regparser here with the eventual goal of breaking off the parts
 # we're using in the RegML parser into a library both can share.
@@ -26,7 +23,7 @@ def get_parent_label(label_parts):
     parent_label = None
 
     # It can't have a parent if it's only one part
-    if len(label_parts) <= 1: 
+    if len(label_parts) <= 1:
         return parent_label
 
     # Not an interpretation label. This is easy.
@@ -41,14 +38,14 @@ def get_parent_label(label_parts):
     return parent_label
 
 
-def get_sibling_label(label_parts): 
+def get_sibling_label(label_parts):
     """ Determine the preceding sibling label for the given label part
         list, if one exists. """
     sibling_label = []
 
     # It can't have a sibling if it's only one part
-    if len(label_parts) <= 1: 
-        return parent_label
+    if len(label_parts) <= 1:
+        return sibling_label
 
     # Start with the parent label. We don't funk interp-resolution here
     # so we won't use the get_parent_label function.
@@ -102,10 +99,13 @@ def process_changes(original_xml, notice_xml, dry=False):
         new_xml.replace(preamble_elm, notice_preamble_elm)
 
     # Get the changes from the notice_xml and iterate over them
-    deletions = notice_xml.findall('.//{eregs}change[@operation="deleted"]')
-    modifications = notice_xml.findall('.//{eregs}change[@operation="modified"]')
-    additions = notice_xml.findall('.//{eregs}change[@operation="added"]')
-    
+    deletions = notice_xml.findall(
+        './/{eregs}change[@operation="deleted"]')
+    modifications = notice_xml.findall(
+        './/{eregs}change[@operation="modified"]')
+    additions = notice_xml.findall(
+        './/{eregs}change[@operation="added"]')
+
     # Sort them appropriately by label
     get_label = lambda c: c.get('label')
     deletions = list(reversed(sorted(deletions, key=get_label)))
@@ -125,7 +125,7 @@ def process_changes(original_xml, notice_xml, dry=False):
             label_parts = label.split('-')
             new_elm = change.getchildren()[0]
             new_index = 0
-            
+
             # Get the parent of the added label
             parent_label = '-'.join(get_parent_label(label_parts))
             parent_elm = new_xml.find('.//*[@label="{}"]'.format(parent_label))
@@ -134,7 +134,8 @@ def process_changes(original_xml, notice_xml, dry=False):
             sibling_label_parts = get_sibling_label(label_parts)
             if sibling_label_parts is not None:
                 sibling_label = '-'.join(sibling_label_parts)
-                sibling_elm = new_xml.find('.//*[@label="{}"]'.format(sibling_label))
+                sibling_elm = new_xml.find(
+                    './/*[@label="{}"]'.format(sibling_label))
 
                 # Figure out where we're inserting this element
                 new_index = parent_elm.index(sibling_elm) + 1
@@ -172,7 +173,7 @@ def process_changes(original_xml, notice_xml, dry=False):
 
 def generate_diff(left_xml, right_xml):
     """ Given two full RegML trees, generate a dictionary of changes
-        between the two in the style of regulations-parser. 
+        between the two in the style of regulations-parser.
         This wraps regulatons-parser's changes_between() function. """
     left_tree = build_reg_tree(left_xml)
     right_tree = build_reg_tree(right_xml)

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from copy import deepcopy
+import itertools
+import string
+
+from lxml import etree
+
+
+# XXX: We should import the same code from regparser. But it needs to be
+# installable first.
+def roman_nums():
+    """Generator for roman numerals."""
+    mapping = [
+        (1, 'i'), (4, 'iv'), (5, 'v'), (9, 'ix'),
+        (10, 'x'), (40, 'xl'), (50, 'l'), (90, 'xc'),
+        (100, 'c'), (400, 'cd'), (500, 'd'), (900, 'cm'),
+        (1000, 'm')
+        ]
+    i = 1
+    while True:
+        next_str = ''
+        remaining_int = i
+        remaining_mapping = list(mapping)
+        while remaining_mapping:
+            (amount, chars) = remaining_mapping.pop()
+            while remaining_int >= amount:
+                next_str += chars
+                remaining_int -= amount
+        yield next_str
+        i += 1
+
+
+p_levels = [
+    list(string.ascii_lowercase),
+    [str(i) for i in range(1, 51)],
+    list(itertools.islice(roman_nums(), 0, 50)),
+    list(string.ascii_uppercase),
+]
+
+
+def get_parent_label(label_parts):
+    """ Determine the parent label for the given label part list. """
+    parent_label = None
+
+    # It can't have a parent if it's only one part
+    if len(label_parts) <= 1: 
+        return parent_label
+
+    # Not an interpretation label. This is easy.
+    parent_label = label_parts[0:-1]
+
+    if label_parts[-1] == 'Interp':
+        # It's the whole interp for the label. Get the parent and
+        # add Interp again.
+        parent_label = get_parent_label(parent_label)
+        parent_label.append('Interp')
+
+    return parent_label
+
+
+def get_sibling_label(label_parts): 
+    """ Determine the preceding sibling label for the given label part
+        list, if one exists. """
+    sibling_label = []
+
+    # It can't have a sibling if it's only one part
+    if len(label_parts) <= 1: 
+        return parent_label
+
+    # Start with the parent label. We don't funk interp-resolution here
+    # so we won't use the get_parent_label function.
+    sibling_label = label_parts[0:-1]
+    last_part = label_parts[-1]
+    if label_parts[-1] == 'Interp':
+        # If this is an interpretation, we'll find the original marker's
+        # sibling and then add 'Interp' to it at the end.
+        last_part = label_parts[-2]
+        sibling_label = label_parts[0:-2]
+
+    # Now find the preceding marker for the last marker.
+    for level in p_levels:
+        if last_part in level:
+            index = level.index(last_part)
+            if index > 0:
+                sibling_label.append(level[index - 1])
+            else:
+                # There is no preceding sibling
+                return None
+            break
+
+    if label_parts[-1] == 'Interp':
+        # Restore 'Interp' to the sibling label
+        sibling_label.append('Interp')
+
+    if len(sibling_label) != len(label_parts):
+        # We weren't able to find the last part in the marker levels?
+        raise IndexError("Unable to locate sibling for '{}'".format(
+            last_part))
+
+    return sibling_label
+
+
+def process_changes(original_xml, notice_xml):
+    """ Process changes given in the notice xml to modify the
+        original_xml. The result is returned as a new XML tree. """
+
+    # Copy the original XML for our new tree
+    new_xml = deepcopy(original_xml)
+
+    # Replace the fdsys and preamble with the notice preamble.
+    fdsys_elm = new_xml.find('./{eregs}fdsys')
+    notice_fdsys_elm = notice_xml.find('./{eregs}fdsys')
+    new_xml.replace(fdsys_elm, notice_fdsys_elm)
+
+    preamble_elm = new_xml.find('./{eregs}preamble')
+    notice_preamble_elm = notice_xml.find('./{eregs}preamble')
+    new_xml.replace(preamble_elm, notice_preamble_elm)
+
+    # Get the changes from the notice_xml and iterate over them
+    changes = notice_xml.findall('.//{eregs}change')
+
+    for change in changes:
+        label = change.get('label')
+        op = change.get('operation')
+
+        # For added labels, we need to break up the label and find its
+        # parent and its preceding sibling to know where to add it.
+        if op == 'added':
+            label_parts = label.split('-')
+            new_elm = change.getchildren()[0]
+            new_index = 0
+            
+            # Get the parent of the added label
+            parent_label = '-'.join(get_parent_label(label_parts))
+            parent_elm = new_xml.find('.//*[@label="{}"]'.format(parent_label))
+
+            # Get the sibling of the added label
+            sibling_label_parts = get_sibling_label(label_parts)
+            if sibling_label_parts is not None:
+                sibling_label = '-'.join(sibling_label_parts)
+                sibling_elm = new_xml.find('.//*[@label="{}"]'.format(sibling_label))
+
+                # Figure out where we're inserting this element
+                new_index = parent_elm.index(sibling_elm) + 1
+
+            # Insert it!
+            parent_elm.insert(new_index, new_elm)
+
+        if op in ('modified', 'deleted'):
+            # Find a match to the given label
+            matching_elm = new_xml.find('.//*[@label="{}"]'.format(label))
+            if matching_elm is None:
+                raise KeyError("Unable to find label {} {} in "
+                               "notice.".format(label, op))
+
+            match_parent = matching_elm.getparent()
+
+            # For modified labels, just find the node and replace it.
+            if op == 'modified':
+                if len(change.getchildren()) == 0:
+                    raise ValueError("Tried to modify {}, but no "
+                                     "replacement given".format(label))
+
+                new_elm = change.getchildren()[0]
+                match_parent.replace(matching_elm, new_elm)
+
+            # For deleted labels, find the node and remove it.
+            if op == 'deleted':
+                match_parent.remove(matching_elm)
+
+    return new_xml

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -10,7 +10,6 @@ import hashlib
 class RegNode:
 
     def __init__(self, **kwargs):
-
         self.label = []
         self.marker = None
         self.children = []
@@ -32,7 +31,6 @@ class RegNode:
             self.include_children = False
 
     def to_json(self):
-
         node_dict = OrderedDict()
 
         if self.include_children:
@@ -54,11 +52,13 @@ class RegNode:
         return node_dict
 
     def __repr__(self):
-
         return json.dumps(self.to_json(), indent=4)
 
-    def __str__(self):
-        return self.__repr__()
+    def __cmp__(self, other):
+        return cmp(repr(self), repr(other))
+
+    def label_id(self):
+        return '-'.join(self.label)
 
     def __eq__(self, other):
         if self.__class__ == other.__class__ and self.interior_hash == other.interior_hash:
@@ -275,6 +275,7 @@ def interpolate_string(text, offsets, values, colorize=False):
         result = result + text[current_pos:]
     return result
 
+
 def enclosed_in_tag(source_text, tag, loc):
     trailing_text = source_text[loc:]
     close_tag = '</{}>'.format(tag)
@@ -289,3 +290,5 @@ def enclosed_in_tag(source_text, tag, loc):
             return True
         else:
             return False
+
+

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -54,6 +54,9 @@ class RegNode:
     def __repr__(self):
         return json.dumps(self.to_json(), indent=4)
 
+    def __str__(self):
+        return self.__repr__()
+
     def __cmp__(self, other):
         return cmp(repr(self), repr(other))
 

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -293,5 +293,3 @@ def enclosed_in_tag(source_text, tag, loc):
             return True
         else:
             return False
-
-

--- a/regulation/settings.py
+++ b/regulation/settings.py
@@ -8,7 +8,8 @@ import sys
 
 # Try to load the settings module
 try:
-    local_settings = importlib.import_module(os.environ.get('REGML_SETTINGS_FILE'))
+    local_settings = importlib.import_module(
+            os.environ.get('REGML_SETTINGS_FILE', 'settings'))
     globals().update(local_settings.__dict__)
 except ImportError:
     logger.error("Unable to import settings module. "

--- a/regulation/settings.py
+++ b/regulation/settings.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import importlib
+import os
+import sys
+
+# Try to load the settings module
+try:
+    local_settings = importlib.import_module(os.environ.get('REGML_SETTINGS_FILE'))
+    globals().update(local_settings.__dict__)
+except ImportError:
+    logger.error("Unable to import settings module. "
+                 "Please double-check your REGML_SETTINGS_FILE "
+                 "environment variable")
+    sys.exit(1)
+
+globals().update(local_settings.__dict__)

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -495,7 +495,7 @@ def build_toc_layer(root):
 
     part = root.find('{eregs}part')
     part_toc = part.find('{eregs}tableOfContents')
-    part_number = part.get('partNumber')
+    part_number = part.get('label')
     toc_dict[part_number] = []
     appendix_letters = []
 
@@ -683,7 +683,7 @@ def build_notice(root):
     Notices currently contain analysis and footnotes
     """
     # Get the root label
-    label = root.find('.//{eregs}part').attrib['partNumber']
+    label = root.find('.//{eregs}part').attrib['label']
 
     # Get regulation dates, document number, and url for the notice
     publication_date = root.find('.//{eregs}fdsys/{eregs}date').text

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -227,7 +227,7 @@ def build_internal_citations_layer(root):
             cite_targets[text] = target
             running_par_text = ''
 
-        for cite, positions in cite_positions.iteritems():
+        for cite, positions in cite_positions.items():
             # positions = find_all_occurrences(par_text, text)
             for pos in positions:
                 #print cite, positions, par_label
@@ -453,8 +453,8 @@ def build_terms_layer(root):
 
             text = term.text
             target = term.get('target')
-            # print [(key, defn) for key, defn in definitions_dict.iteritems()], target
-            defn_location = [key for key, defn in definitions_dict.iteritems() if defn['reference'] == target]
+            # print [(key, defn) for key, defn in definitions_dict.items()], target
+            defn_location = [key for key, defn in definitions_dict.items() if defn['reference'] == target]
             if len(defn_location) > 0:
                 defn_location = defn_location[0]
 
@@ -471,7 +471,7 @@ def build_terms_layer(root):
                 term_positions.setdefault(text, []).append(term_position)
                 term_targets[text] = defn_location
 
-        for term, positions in term_positions.iteritems():
+        for term, positions in term_positions.items():
             target = term_targets[term]
             ref_dict = OrderedDict()
             ref_dict['offsets'] = []

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-try:
-    from enum import Enum
-except ImportError:
-    from flufl.enum import Enum
+from enum import Enum
 
 from termcolor import colored, cprint
 from lxml import etree
@@ -12,8 +9,8 @@ from .node import xml_node_text, find_all_occurrences, interpolate_string, enclo
 
 import inflect
 import re
-import json
-import settings
+
+import regulation.settings as settings
 
 
 class Severity(Enum):

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from enum import Enum
 from termcolor import colored, cprint
 from lxml import etree
-from node import xml_node_text, find_all_occurrences, interpolate_string, enclosed_in_tag
+from .node import xml_node_text, find_all_occurrences, interpolate_string, enclosed_in_tag
 
 import inflect
 import re
@@ -202,7 +203,7 @@ class EregsValidator:
                                 msg = colored('You appear to have used the term "{}" in {} without referencing it: \n'.format(term_to_use, label), 'yellow') + \
                                       '{}\n'.format(highlighted_par) + \
                                       colored('Would you like the automatically fix this reference in the source?', 'yellow')
-                                print msg
+                                print(msg)
                                 while input_state not in ['y', 'n', 'i']:
                                     input_state = raw_input('(y)es/(n)o/(i)gnore this term: ')
 
@@ -222,11 +223,11 @@ class EregsValidator:
                 highlight = interpolate_string(par_text, offsets, values, colorize=True)
                 new_content = etree.fromstring(new_par_text)
                 paragraph.replace(content, new_content)
-                print highlight
+                print(highlight)
 
 
         if problem_flag:
-            print colored('The tree has been altered! Do you want to write the result to disk?')
+            print(colored('The tree has been altered! Do you want to write the result to disk?'))
             answer = None
             while answer not in ['y', 'n']:
                 answer = raw_input('Save? y/n: ')

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from enum import Enum
+try:
+    from enum import Enum
+except ImportError:
+    from flufl.enum import Enum
+
 from termcolor import colored, cprint
 from lxml import etree
 from .node import xml_node_text, find_all_occurrences, interpolate_string, enclosed_in_tag

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click=6.2
+click==6.2
 enum34==1.1.2
 inflect==0.2.5
 lxml==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click=6.2
-flufl.enum=4.1
+enum34==1.1.2
 inflect==0.2.5
 lxml==3.5.0
 termcolor==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+click=6.2
+flufl.enum=4.1
 inflect==0.2.5
 lxml==3.5.0
 termcolor==1.1.0
+-e git+https://github.com/willbarton/regulations-configs.git#egg=regulations_configs
+-e git+https://github.com/willbarton/regulations-parser@xml-writer-devel#egg=regulations_parser

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,8 @@
-__author__ = 'vinokurovy'
-
 import os
 
-XML_ROOT = '../regulations-schema/src'
-JSON_ROOT = '../regulations-xml-json/'
-XSD_FILE = os.path.join(XML_ROOT, 'eregs.xsd')
+XML_ROOT = '../regulations-stub/xml'
+JSON_ROOT = '../regulations-stub/stub'
+XSD_FILE = '../regulations-schema/src/eregs.xsd'
 
 # the inflect module has a few problems... manual override for that
 
@@ -12,3 +10,11 @@ SPECIAL_SINGULAR_NOUNS = [
     'bonus',
     'escrow account analysis'
 ]
+
+## eCFR Parser Settings
+from regparser.default_settings import *
+
+# OUTPUT_DIR=os.environ.get('OUTPUT_DIR', "../regulations-stub/stub/")
+OUTPUT_DIR=os.environ.get('OUTPUT_DIR', "../regulations-stub/xml/")
+# OUTPUT_DIR="../regulations-stub/stub/"
+LOCAL_XML_PATHS = ['../fr-notices/',]

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,7 +15,7 @@ test_xml = """
             <effectiveDate>2015-11-17</effectiveDate>
             <federalRegisterURL>https://www.federalregister.gov/some/url/</federalRegisterURL>
           </preamble>
-          <part partNumber="1234">
+          <part label="1234">
             <content>
 
               <subpart>

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+import lxml.etree as etree
+
+from regulation.changes import get_parent_label, get_sibling_label, process_changes
+
+class ChangesTests(TestCase):
+
+    def test_get_parent_label_normal(self):
+        label_parts = ['1234', '1', 'g', '2']
+        self.assertEqual(['1234', '1', 'g'], get_parent_label(label_parts))
+
+    def test_get_parent_label_root(self):
+        label_parts = ['1234']
+        self.assertEqual(None, get_parent_label(label_parts))
+
+    def test_get_parent_label_interps(self):
+        label_parts = ['1234', '1', 'g', '2', 'Interp']
+        self.assertEqual(['1234', '1', 'g', 'Interp'], get_parent_label(label_parts))
+
+        label_parts = ['1234', '1', 'g', '2', 'Interp', '2']
+        self.assertEqual(['1234', '1', 'g', '2', 'Interp'], get_parent_label(label_parts))
+
+    def test_get_sibling_label_alpha(self):
+        label_parts = ['1234', '1', 'g']
+        self.assertEqual(['1234', '1', 'f'], get_sibling_label(label_parts))
+
+    def test_get_sibling_label_numeric(self):
+        label_parts = ['1234', '2']
+        self.assertEqual(['1234', '1'], get_sibling_label(label_parts))
+
+    def test_get_sibling_label_interp(self):
+        label_parts = ['1234', '1', 'g', '2', 'Interp']
+        self.assertEqual(['1234', '1', 'g', '1', 'Interp'], get_sibling_label(label_parts))
+
+    def test_get_sibling_label_none(self):
+        label_parts = ['1234', '1', 'a']
+        self.assertEqual(None, get_sibling_label(label_parts))
+
+    def test_process_changes_meta(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys>
+                This is an fdsys 
+              </fdsys>
+              <preamble>
+                This is the preamble
+              </preamble>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys>
+                Old fdsys
+              </fdsys>
+              <preamble>
+                Old preamble
+              </preamble>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        fdsys = new_xml.find('./{eregs}fdsys')
+        preamble = new_xml.find('./{eregs}preamble')
+        self.assertTrue("This is an fdsys" in fdsys.text)
+        self.assertTrue("This is the preamble" in preamble.text)
+
+    def test_process_changes_added(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="added" label="1234-2">
+                  <paragraph label="1234-2">An added paragraph</paragraph>
+                </change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <paragraph label="1234-1">An existing paragraph</paragraph>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        new_para = new_xml.find('.//{eregs}paragraph[@label="1234-2"]')
+        self.assertNotEqual(new_para, None)
+        self.assertEqual("An added paragraph", new_para.text)
+        self.assertEqual(new_para.getparent().index(new_para), 1)
+
+    def test_process_changes_added_first_child(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="added" label="1234-1">
+                  <paragraph label="1234-1">An added paragraph</paragraph>
+                </change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        new_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertNotEqual(new_para, None)
+        self.assertEqual("An added paragraph", new_para.text)
+
+    def test_process_changes_modified(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="modified" label="1234-1">
+                  <paragraph label="1234-1">A modified paragraph</paragraph>
+                </change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <paragraph label="1234-1">An existing paragraph</paragraph>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        mod_paras = new_xml.findall('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertEqual(len(mod_paras), 1)
+        self.assertNotEqual(mod_paras[0], None)
+        self.assertEqual("A modified paragraph", mod_paras[0].text)
+
+    def test_process_changes_deleted(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="deleted" label="1234-1"></change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <paragraph label="1234-1">An existing paragraph</paragraph>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        del_paras = new_xml.findall('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertEqual(len(del_paras), 0)
+
+    def test_process_changes_nolabel(self):
+        pass
+    

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -2,21 +2,18 @@
 
 from unittest import TestCase
 
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
-
 import lxml.etree as etree
 
 from regulation.changes import (get_parent_label, get_sibling_label,
                                 process_changes, generate_diff)
 
+
 class ChangesTests(TestCase):
 
     def test_get_parent_label_normal(self):
         label_parts = ['1234', '1', 'g', '2']
-        self.assertEqual(['1234', '1', 'g'], get_parent_label(label_parts))
+        self.assertEqual(['1234', '1', 'g'],
+                         get_parent_label(label_parts))
 
     def test_get_parent_label_root(self):
         label_parts = ['1234']
@@ -24,22 +21,27 @@ class ChangesTests(TestCase):
 
     def test_get_parent_label_interps(self):
         label_parts = ['1234', '1', 'g', '2', 'Interp']
-        self.assertEqual(['1234', '1', 'g', 'Interp'], get_parent_label(label_parts))
+        self.assertEqual(['1234', '1', 'g', 'Interp'],
+                         get_parent_label(label_parts))
 
         label_parts = ['1234', '1', 'g', '2', 'Interp', '2']
-        self.assertEqual(['1234', '1', 'g', '2', 'Interp'], get_parent_label(label_parts))
+        self.assertEqual(['1234', '1', 'g', '2', 'Interp'],
+                         get_parent_label(label_parts))
 
     def test_get_sibling_label_alpha(self):
         label_parts = ['1234', '1', 'g']
-        self.assertEqual(['1234', '1', 'f'], get_sibling_label(label_parts))
+        self.assertEqual(['1234', '1', 'f'],
+                         get_sibling_label(label_parts))
 
     def test_get_sibling_label_numeric(self):
         label_parts = ['1234', '2']
-        self.assertEqual(['1234', '1'], get_sibling_label(label_parts))
+        self.assertEqual(['1234', '1'],
+                         get_sibling_label(label_parts))
 
     def test_get_sibling_label_interp(self):
         label_parts = ['1234', '1', 'g', '2', 'Interp']
-        self.assertEqual(['1234', '1', 'g', '1', 'Interp'], get_sibling_label(label_parts))
+        self.assertEqual(['1234', '1', 'g', '1', 'Interp'],
+                         get_sibling_label(label_parts))
 
     def test_get_sibling_label_none(self):
         label_parts = ['1234', '1', 'a']
@@ -63,7 +65,7 @@ class ChangesTests(TestCase):
               <preamble>
                 Old preamble
               </preamble>
-            </regulation>""")
+            </regulation>""") # noqa
         new_xml = process_changes(original_xml, notice_xml)
         fdsys = new_xml.find('./{eregs}fdsys')
         preamble = new_xml.find('./{eregs}preamble')
@@ -325,4 +327,3 @@ class ChangesTests(TestCase):
         self.assertEqual(len(diff.keys()), 1)
         self.assertTrue('1234-1-a' in diff)
         self.assertEqual(diff['1234-1-a']['op'], 'deleted')
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,flake8
+envlist = py27
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR adds history functionality in conjunction with recent changes to [regulations-parser@xml-writer-devel](https://github.com/cfpb/regulations-parser/tree/xml-writer-devel). 

With this, along with the new `regml.py` script, the eCFR parser can be invoked, notice changesets generated, and then applied as described in the README [here](https://github.com/willbarton/regulations-xml-parser/blob/history/README.md#generating-regml-from-ecfr) [and here](https://github.com/willbarton/regulations-xml-parser/blob/history/README.md#generating-regml-from-regulation--notice).

Diff JSON can be generated automatically when multiple RegML files are given to generate JSON, again as described in the [README](https://github.com/willbarton/regulations-xml-parser/blob/history/README.md#generating-json-from-regml).

It adds tests for the history and diffing functionality and makes some minor Python-friendly modifications to dictionary iteration (`iteritems()` -> `items()`) and printing.
