### PR TITLE
Fix diff JSON output

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -243,8 +243,8 @@ def json_command(regulation_files, check_terms=False):
     for left_version, left_tree in versions.items():
         for right_version, right_tree in versions.items():
             diff = generate_diff(left_tree, right_tree)
-            write_layer(diff, reg_number, left_version, 'diff',
-                        diff_notice=right_version)
+            write_layer(diff, reg_number, right_version, 'diff',
+                        diff_notice=left_version)
 
 
 # Given a notice, apply it to a previous RegML regulation verson to


### PR DESCRIPTION
This fixes diff JSON output by putting the notice numbers in the correct order. Previously they were `part/new/old`, reg-site expects `part/old/new`.
