### PR TITLE
Unicode literals for Python 2.7

### DIFF
--- a/regulation/node.py
+++ b/regulation/node.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 from termcolor import colored
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 import inflect


### PR DESCRIPTION
This PR ensures that we’re using unicode literals in Python 2.7 when building the node tree from XML.
