### PR TITLE
Tweak the term finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ To validate a RegML file against
 ./regml.py validate [RegML regulation or notice file]
 ```
 
+## RegML Sanitization
+
+Some utilities to sanitize RegML are also included
+
+
+### Term Finder
+
+The term finder prompts the user to place references to defined terms 
+wherever they may be found. These corrections can then be writen back to
+the original RegML file.
+
+```shell
+./regml.py check-terms [RegML regulation file] 
+```
+
+`check-terms` also takes an optional label, which will cause it to only
+operate on that particular part of the regulation (useful for large
+regulations). For example:
+
+```
+./regml.py check-terms 1026/2011-31715 --label 1026-1 
+You appear to have used the term "Credit" in 1026-1-a without referencing it: 
+<content xmlns="eregs">...</content>
+            
+Would you like the automatically fix this reference in the source?
+(y)es/(n)o/(i)gnore this term/(a)lways correct: 
+```
+
 ## Generating JSON from RegML
 
 To generate JSON from RegML for use with

--- a/regml.py
+++ b/regml.py
@@ -211,7 +211,7 @@ def validate(file):
     return validator
 
 
-@cli.command()
+@cli.command('check-terms')
 @click.argument('file')
 @click.option('--label')
 def check_terms(file, label=None):

--- a/regml.py
+++ b/regml.py
@@ -179,7 +179,8 @@ def cli():
 @click.option('--check-terms')
 def validate(file, check_terms=None):
     """ Validate a RegML file """
-    with open(find_file(file), 'r') as f:
+    file = find_file(file)
+    with open(file, 'r') as f:
         reg_xml = f.read()
     xml_tree = etree.fromstring(reg_xml)
 
@@ -221,7 +222,7 @@ def validate(file, check_terms=None):
 @cli.command('json')
 @click.argument('regulation_files', nargs=-1, required=True)
 @click.option('--check-terms', is_flag=True)
-def json_command(regulation_files, check_terms=False):
+def json_command(regulation_files, from_notices=[], check_terms=False):
     """ Generate JSON from RegML files """
 
     # If the "file" is a directory, assume we want to operate on all the
@@ -286,12 +287,15 @@ def apply(regulation_file, notice_file):
 @cli.command()
 @click.argument('title')
 @click.argument('part')
-def noticelist(title, part):
+def versions(title, part):
     """ List notices for regulation title/part """
     notices = fetch_notice_json(title, part, only_final=True)
     doc_numbers = [n['document_number'] for n in notices]
-    for number in doc_numbers:
-        print(number)
+    for n in notices:
+        print(n['document_number'], n['effective_on'])
+
+    # for number in doc_numbers:
+    #     print(number)
 
 
 # eCFR Convenience Commands ############################################

--- a/regml.py
+++ b/regml.py
@@ -175,9 +175,9 @@ def cli():
 # Perform validation on the given RegML file without any additional
 # actions.
 @cli.command()
-@click.option('--check-terms', default=False)
 @click.argument('file')
-def validate(check_terms, file):
+@click.option('--check-terms')
+def validate(file, check_terms=None):
     """ Validate a RegML file """
     with open(find_file(file), 'r') as f:
         reg_xml = f.read()
@@ -200,8 +200,9 @@ def validate(check_terms, file):
         validator.validate_terms(xml_tree, terms)
         validator.validate_internal_cites(xml_tree, internal_citations)
 
-        if check_terms:
-            validator.validate_term_references(xml_tree, terms, file)
+        if check_terms is not None:
+            validator.validate_term_references(xml_tree, terms, file,
+                    label=check_terms)
         for event in validator.events:
             print(str(event))
 

--- a/regml.py
+++ b/regml.py
@@ -333,7 +333,7 @@ def ecfr(title, file, act_title, act_section,
     for last_notice, old, new_tree, notices in builder.revision_generator(
             reg_tree):
         version = last_notice['document_number']
-        print("Version %s", version)
+        print("Version", version)
         builder.doc_number = version
         layers = builder.generate_layers(new_tree,
                                          [act_title, act_section],

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -170,11 +170,10 @@ class EregsValidator:
         inf = inflect.engine()
 
         definitions = terms_layer['referenced']
-        terms = [(defn['term'], defn['reference']) for key, defn in definitions.iteritems()]
-        cap_terms = [(defn['term'][0].upper() + defn['term'][1:], defn['reference'])
-                     for key, defn in definitions.iteritems()]
-
-        terms = terms + cap_terms
+        terms = set([(defn['term'], defn['reference']) for key, defn in definitions.iteritems()])
+        cap_terms = set([(defn['term'][0].upper() + defn['term'][1:], defn['reference'])
+                     for key, defn in definitions.iteritems()])
+        terms = terms | cap_terms
 
         # Pick out our working section of the tree. If no label was
         # given, it *is* the tree.
@@ -216,10 +215,7 @@ class EregsValidator:
                                       '{}\n'.format(highlighted_par) + \
                                       colored('Would you like the automatically fix this reference in the source?', 'yellow')
                                 print(msg)
-                                while input_state not in ['y', 'n', 'i']:
-                                    input_state = raw_input('(y)es/(n)o/(i)gnore this term: ')
 
-                                if input_state == 'y':
                                     problem_flag = True
                                     ref = '<ref target="{}" reftype="term">{}</ref>'.format(term[1], term_to_use)
                                     offsets_and_values.append((ref, [term_loc, term_loc + len(term_to_use)]))

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -185,6 +185,7 @@ class EregsValidator:
         paragraphs = working_section.findall('.//{eregs}paragraph') + \
                 working_section.findall('.//{eregs}interpParagraph')
         ignore = set()
+        always = set()
 
         for paragraph in paragraphs:
             content = paragraph.find('.//{eregs}content')
@@ -215,10 +216,17 @@ class EregsValidator:
                                       '{}\n'.format(highlighted_par) + \
                                       colored('Would you like the automatically fix this reference in the source?', 'yellow')
                                 print(msg)
+                                if term[0] not in always:
+                                    while input_state not in ['y', 'n', 'i', 'a']:
+                                        input_state = raw_input('(y)es/(n)o/(i)gnore this term/(a)lways correct: ')
 
+                                if input_state in ['y', 'a'] or term[0] in always:
                                     problem_flag = True
                                     ref = '<ref target="{}" reftype="term">{}</ref>'.format(term[1], term_to_use)
                                     offsets_and_values.append((ref, [term_loc, term_loc + len(term_to_use)]))
+                                    if input_state == 'a':
+                                        always.add(term[0])
+                                    
                                 elif input_state == 'i':
                                     ignore.add(term[0])
 

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -292,6 +292,60 @@ class EregsValidator:
 
         self.events.append(event)
 
+    def headerize_interps(self, tree, regulation_file):
+        paragraphs = tree.findall('.//{eregs}interpParagraph')
+        change_flag = False
+
+        for paragraph in paragraphs:
+            title = paragraph.find('{eregs}title')
+            content = paragraph.find('{eregs}content')
+            label = paragraph.get('label')
+            marker = paragraph.get('marker', '')
+            target = paragraph.get('target', '')
+
+            if title is None:
+                current_par = etree.tostring(paragraph)
+                print(colored(current_par, 'yellow'))
+                response = None
+                while response not in ['y', 'n']:
+                    msg = colored('Do you want to titleize this paragraph?')
+                    print(msg)
+                    response = raw_input('(y)es/(n)o: ')
+                if response.lower() == 'y':
+                    response = None
+                    content_text = content.text
+                    first_period = content_text.find('.')
+                    if first_period > -1:
+                        title_string = content_text[:first_period + 1]
+                        new_title = '<title>' + title_string + '</title>'
+                        new_text = '<content>' + xml_node_text(content).replace(title_string, '').strip() + '</content>'
+                        paragraph.insert(0, etree.fromstring(new_title))
+
+                        #new_paragraph = '<interpParagraph label="{}" target="{}" marker="{}">\n'.format(label, target, marker)
+                        #new_paragraph += new_title + '\n'
+                        #new_paragraph += new_text + '\n</interpParagraph>'
+                        #print(colored(new_paragraph, 'green'))
+
+                        change_flag = True
+                    else:
+                        print(colored('Nothing to headerize!', 'red'))
+
+    def insert_interp_markers(self, tree, regulation_file):
+        """ Add in the markers for interp paragraphs in situations where 
+            they're missing. """
+        paragraphs = tree.findall('.//{eregs}interpParagraph')
+        for paragraph in paragraphs:
+            label = paragraph.get('label')
+            split_label = label.split('-')
+            if 'Interp' in split_label:
+                index = split_label.index('Interp')
+                if index + 1 < len(split_label) and split_label[index + 1].isdigit():
+                    marker = split_label[-1] + '.'
+                    paragraph.set('marker', marker)
+
+        with open(regulation_file, 'w') as f:
+            f.write(etree.tostring(tree, pretty_print=True))
+
     @property
     def is_valid(self):
         for error in self.events:

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -183,8 +183,6 @@ class EregsValidator:
             working_section = tree.find(
                     './/*[@label="{}"]'.format(label))
 
-        import pdb; pdb.set_trace()
-
         paragraphs = working_section.findall('.//{eregs}paragraph') + \
                 working_section.findall('.//{eregs}interpParagraph')
         ignore = set()

--- a/settings.py
+++ b/settings.py
@@ -1,20 +1,24 @@
 import os
 
-XML_ROOT = '../regulations-stub/xml'
-JSON_ROOT = '../regulations-xml-json'
-XSD_FILE = '../regulations-schema/src/eregs.xsd'
+XML_ROOT = '../regulations-xml'
+JSON_ROOT = '../regulations-stub/stub'
+XSD_FILE = 'http://cfpb.github.io/regulations-schema/src/eregs.xsd'
 
 # the inflect module has a few problems... manual override for that
-
 SPECIAL_SINGULAR_NOUNS = [
     'bonus',
     'escrow account analysis'
 ]
 
 ## eCFR Parser Settings
-from regparser.default_settings import *
 
-# OUTPUT_DIR=os.environ.get('OUTPUT_DIR', "../regulations-stub/stub/")
-OUTPUT_DIR=os.environ.get('OUTPUT_DIR', "../regulations-xml/")
-# OUTPUT_DIR="../regulations-stub/stub/"
+# Try to import configuration from a Python package called 'regconfig'. If
+# it doesn't exist, just go with our default settings.
+try:
+    from regconfig import *
+except ImportError:
+    from regparser.default_settings import *
+
+# OUTPUT_DIR=os.environ.get('OUTPUT_DIR', JSON_ROOT)
+OUTPUT_DIR=os.environ.get('OUTPUT_DIR', XML_ROOT)
 LOCAL_XML_PATHS = ['../fr-notices/',]


### PR DESCRIPTION
This PR adds a separate command for the term finder to `regml.py` and adds the ability to specify a particular label (i.e. a section like 1026-1) within the regulation to run the term finder on. So we can now run it like this:

```
./regml.py check-terms 1026/2011-31715 --label 1026-40
```

Also contained are some minor bug fixes such as:
- Remove errant %s in eCFR parsing
- Reducing code repetition in `regml.py` with a `get_validator()` function

@grapesmoker @hillaryj
