### PR TITLE
Validate keyterms

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -183,7 +183,13 @@ def cli():
 # actions.
 @cli.command()
 @click.argument('file')
-def validate(file):
+@click.option('--no-terms', is_flag=True, 
+    help="don't try to validate terms")
+@click.option('--no-citations', is_flag=True, 
+    help="don't try to validate citations")
+@click.option('--no-keyterms', is_flag=True, 
+    help="don't try to validate keyterms")
+def validate(file, no_terms=False, no_citations=False, no_keyterms=False):
     """ Validate a RegML file """
     file = find_file(file)
     with open(file, 'r') as f:
@@ -198,8 +204,12 @@ def validate(file):
         terms = build_terms_layer(xml_tree)
         internal_citations = build_internal_citations_layer(xml_tree)
 
-        validator.validate_terms(xml_tree, terms)
-        validator.validate_internal_cites(xml_tree, internal_citations)
+        if not no_terms:
+            validator.validate_terms(xml_tree, terms)
+        if not no_citations:
+            validator.validate_internal_cites(xml_tree, internal_citations)
+        if not no_keyterms:
+            validator.validate_keyterms(xml_tree)
 
         for event in validator.events:
             print(str(event))

--- a/regml.py
+++ b/regml.py
@@ -136,6 +136,7 @@ def generate_json(regulation_file, check_terms=False):
 
     validator.validate_terms(xml_tree, terms)
     validator.validate_internal_cites(xml_tree, internal_citations)
+    validator.validate_keyterms(xml_tree)
     if check_terms:
         validator.validate_term_references(xml_tree, terms, regulation_file)
     for event in validator.events:

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -640,13 +640,19 @@ def build_interp_layer(root):
         first_label = interpretations.get('label')
         first_key = first_label.split('-')[0]
         layer_dict[first_key] = [{'reference': first_label}]
+
+        interp_sections = interpretations.findall(
+            './/{eregs}interpSection')
         interp_paragraphs = interpretations.findall(
             './/{eregs}interpParagraph')
-        for paragraph in interp_paragraphs:
-            target = paragraph.get('target')
-            if target:
-                label = paragraph.get('label')
-                layer_dict[target] = [{'reference': label}]
+        targetted_interps = [i for i in 
+            interp_sections + interp_paragraphs
+            if i.get('target') is not None]
+
+        for interp in targetted_interps:
+            target = interp.get('target')
+            label = interp.get('label')
+            layer_dict[target] = [{'reference': label}]
 
     return layer_dict
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -64,18 +64,12 @@ def build_reg_tree(root, parent=None, depth=0):
         children = root.findall('{eregs}paragraph')
 
     elif tag == 'paragraph':
+
         title = root.find('{eregs}title')
         content = root.find('{eregs}content')
         content_text = xml_node_text(content)
-
-        if title is not None:
-            if title.get('type') != 'keyterm':
-                node.title = title.text
-            else:
-                # Keyterms are expected by reg-site to be included in
-                # the content text rather than the title of a node.
-                content_text = title.text + content_text
-
+        if title is not None and title.get('type') != 'keyterm':
+            node.title = title.text
         node.marker = root.get('marker')
         if node.marker == 'none':
             marker = ''

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
+import string
 
 import inflect
 
@@ -83,7 +84,7 @@ def build_reg_tree(root, parent=None, depth=0):
             node.text = '{} {}'.format(marker, content_text).strip()
         node.node_type = parent.node_type
         node.mixed_text = xml_mixed_text(content)
-        node.source_xml = etree.tostring(root)
+        node.source_xml = etree.tostring(root, encoding='UTF-8')
 
         children = root.findall('{eregs}paragraph')
 
@@ -156,7 +157,7 @@ def build_reg_tree(root, parent=None, depth=0):
         node.label = root.get('label').split('-')
         node.text = content_text
         node.node_type = 'interp'
-        node.source_xml = etree.tostring(root)
+        node.source_xml = etree.tostring(root, encoding='UTF-8')
 
         children = root.findall('{eregs}interpParagraph')
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -64,12 +64,18 @@ def build_reg_tree(root, parent=None, depth=0):
         children = root.findall('{eregs}paragraph')
 
     elif tag == 'paragraph':
-
         title = root.find('{eregs}title')
         content = root.find('{eregs}content')
         content_text = xml_node_text(content)
-        if title is not None and title.get('type') != 'keyterm':
-            node.title = title.text
+
+        if title is not None:
+            if title.get('type') != 'keyterm':
+                node.title = title.text
+            else:
+                # Keyterms are expected by reg-site to be included in
+                # the content text rather than the title of a node.
+                content_text = title.text + content_text
+
         node.marker = root.get('marker')
         if node.marker == 'none':
             marker = ''

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import copy
 from enum import Enum
-import string
 import re
 
 from termcolor import colored, cprint

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -105,6 +105,8 @@ class EregsValidator:
         problem_flag = False
         keyterms = tree.findall('.//*[@type="keyterm"]')
 
+        keyterm_events = []
+
         for keyterm in keyterms:
             # Get the parent and its label
             parent = keyterm.getparent()
@@ -134,11 +136,11 @@ class EregsValidator:
                 # If the keyterm is there outright, error.
                 if content.text.startswith(keyterm.text):
                     msg = 'Duplicate keyterm: ' \
-                          'in {} the keyterm "{}" appears both in the title' \
+                          'in {} the keyterm "{}" appears both in the title ' \
                           'and the content.'.format(label, keyterm.text)
                     event = EregsValidationEvent(
                         msg, severity=Severity(Severity.ERROR))
-                    self.events.append(event)
+                    keyterm_events.append(event)
                     problem_flag = True
 
                 # Next we check for possible fragments of the keyterm
@@ -150,12 +152,15 @@ class EregsValidator:
                           'the content.'.format(label, keyterm.text)
                     event = EregsValidationEvent(
                         msg, severity=Severity(Severity.WARNING))
-                    self.events.append(event)
+                    keyterm_events.append(event)
                     problem_flag = True
 
+        self.events = self.events + keyterm_events
 
         if problem_flag:
-            msg = 'There were some problems with repeating keyterms. '
+            msg = 'There were {} potential problems with repeating ' \
+                  'keyterms.'.format(
+                    len(keyterm_events))
             event = EregsValidationEvent(msg, Severity(Severity.WARNING))
         else:
             msg = 'No keyterm titles appear to be repeated'

--- a/tests/common.py
+++ b/tests/common.py
@@ -54,10 +54,13 @@ test_xml = """
 
               <interpretations label="1234-Interp">
                 <title>Supplement I to Part 1234&#8212;Official Interpretations</title>
-                <interpSection label="1234-Interp-h1">
+                <interpSection label="1234-1-Interp" target="1234-1">
                   <title>Introduction</title>
-                  <interpParagraph label="1234-Interp-h1-1" target="1013-h1-1">
+                  <interpParagraph label="1234-1-A-Interp" target="1234-1-A">
                     <content>Some interpretation content here.</content>
+                  </interpParagraph>
+                  <interpParagraph label="1234-1-A-Interp-1">
+                    <content>Interp paragraph without target.</content>
                   </interpParagraph>
                 </interpSection>
               </interpretations>

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from unittest import TestCase
 
@@ -7,6 +8,7 @@ import lxml.etree as etree
 from common import test_xml
 from regulation.tree import (build_reg_tree,
                              build_paragraph_marker_layer,
+                             build_interp_layer,
                              build_analysis,
                              build_notice)
 from regulation.node import RegNode
@@ -17,7 +19,7 @@ class TreeTestCase(TestCase):
     def setUp(self):
         # A basic test regulation tree (add stuff as necessary for
         # testing)
-        self.input_xml = test_xml  # NOQA
+        self.input_xml = test_xml
         self.root = etree.fromstring(self.input_xml)
 
     def tearDown(self):
@@ -44,6 +46,16 @@ class TreeTestCase(TestCase):
         interp_dict = node_dict['children'][2]
         self.assertEqual(interp_dict['label'], ['1234', 'Interp'])
         self.assertEqual(node.children[2].depth, 1)
+
+    def test_build_interp_layer(self):
+        interp_dict = build_interp_layer(self.root)
+        expected_result = {
+                '1234': [{u'reference': '1234-Interp'}], 
+                '1234-1': [{u'reference': '1234-1-Interp'}], 
+                '1234-1-A': [{u'reference': '1234-1-A-Interp'}], 
+        }
+        print(dict(interp_dict))
+        self.assertEqual(expected_result, interp_dict)
 
     def test_build_analysis(self):
         result_analysis = {
@@ -150,8 +162,6 @@ class TreeTestCase(TestCase):
 
         result = reg_tree.flatten()
 
-        print result
-
         self.assertEqual(1, 1)
 
     def test_labels(self):
@@ -160,8 +170,6 @@ class TreeTestCase(TestCase):
         reg_tree = build_reg_tree(xml_tree)
 
         result = reg_tree.labels()
-
-        print result
 
         self.assertEqual(1, 1)
 

--- a/tests/regulation_validation_tests.py
+++ b/tests/regulation_validation_tests.py
@@ -27,8 +27,6 @@ class EregsValidatorTests(TestCase):
         validator = EregsValidator(settings.XSD_FILE)
         validator.validate_keyterms(tree)
 
-        print(validator.events)
-
         self.assertEqual(len(validator.events), 3)
 
         self.assertEqual(validator.events[0].severity, Severity.ERROR)
@@ -39,4 +37,3 @@ class EregsValidatorTests(TestCase):
 
         self.assertEqual(validator.events[2].severity, Severity.WARNING)
         self.assertTrue('repeating keyterms' in validator.events[2].msg)
-

--- a/tests/regulation_validation_tests.py
+++ b/tests/regulation_validation_tests.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+import lxml.etree as etree
+
+from regulation.validation import EregsValidator, Severity
+
+import settings
+
+
+class EregsValidatorTests(TestCase):
+
+    def test_validate_keyterms(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs" >
+          <paragraph>
+            <title type="keyterm">A Keyterm.</title>
+            <content>A Keyterm. This paragraph should error.</content>
+          </paragraph>
+          <paragraph>
+            <title type="keyterm">Another Keyterm.</title>
+            <content>Keyterm. Fragment This one should warn.</content>
+          </paragraph>
+        </section>
+        """)
+        validator = EregsValidator(settings.XSD_FILE)
+        validator.validate_keyterms(tree)
+
+        print(validator.events)
+
+        self.assertEqual(len(validator.events), 3)
+
+        self.assertEqual(validator.events[0].severity, Severity.ERROR)
+        self.assertTrue('Duplicate keyterm' in validator.events[0].msg)
+
+        self.assertEqual(validator.events[1].severity, Severity.WARNING)
+        self.assertTrue('keyterm fragment' in validator.events[1].msg)
+
+        self.assertEqual(validator.events[2].severity, Severity.WARNING)
+        self.assertTrue('repeating keyterms' in validator.events[2].msg)
+


### PR DESCRIPTION
This PR adds a validation method for key terms that checks for full text or fragments in the content element. 

It also adds flags to the `validate` command to disable the terms, citation, and key terms validators as needed.

@hillaryj @grapesmoker 
