### PR TITLE
Formatting extras

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -64,12 +64,13 @@ def build_reg_tree(root, parent=None, depth=0):
         children = root.findall('{eregs}paragraph')
 
     elif tag == 'paragraph':
-
         title = root.find('{eregs}title')
         content = root.find('{eregs}content')
         content_text = xml_node_text(content)
-        if title is not None and title.get('type') != 'keyterm':
+
+        if title is not None:
             node.title = title.text
+
         node.marker = root.get('marker')
         if node.marker == 'none':
             marker = ''
@@ -150,6 +151,7 @@ def build_reg_tree(root, parent=None, depth=0):
         content_text = xml_node_text(content)
         if title is not None:
             node.title = title.text
+
         node.marker = root.get('marker', '')
         if node.marker == 'none':
             node.marker = ''

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -322,7 +322,10 @@ def build_formatting_layer(root):
         content = paragraph.find('{eregs}content')
         dashes = content.findall('.//{eregs}dash')
         tables = content.findall('.//{eregs}table')
+        variables = content.findall('.//{eregs}variable')
+        callouts = content.findall('.//{eregs}callout')
         label = paragraph.get('label')
+
         if len(dashes) > 0:
             layer_dict[label] = []
             for dash in dashes:
@@ -334,6 +337,37 @@ def build_formatting_layer(root):
                 dash_dict['dash_data'] = {'text': dash_text}
                 dash_dict['locations'] = [0]
                 layer_dict[label].append(dash_dict)
+
+        if len(variables) > 0:
+            if label not in layer_dict:
+                layer_dict[label] = []
+
+            for variable in variables:
+                subscript = variable.find('{eregs}subscript')
+                var_dict = OrderedDict()
+                var_dict['subscript_data'] = {
+                    'variable': variable.text,
+                    'subscript': subscript.text,
+                }
+                var_dict['locations'] = [0]
+                var_dict['text'] = ''
+                layer_dict[label].append(var_dict)
+
+        if len(callouts) > 0:
+            if label not in layer_dict:
+                layer_dict[label] = []
+
+            for callout in callouts:
+                lines = callout.findall('{eregs}line')
+                callout_dict = OrderedDict()
+                callout_dict['fence_data'] = {
+                    'lines': [l.text for l in lines],
+                    'type': callout.get('type')
+                }
+                callout_dict['locations'] = [0]
+                callout_dict['text'] = ''
+                layer_dict[label].append(callout_dict)
+
         if len(tables) > 0:
             if label not in layer_dict:
                 layer_dict[label] = []

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -69,7 +69,12 @@ def build_reg_tree(root, parent=None, depth=0):
         content_text = xml_node_text(content)
 
         if title is not None:
-            node.title = title.text
+            if title.get('type') != 'keyterm':
+                node.title = title.text
+            else:
+                # Keyterms are expected by reg-site to be included in
+                # the content text rather than the title of a node.
+                content_text = title.text + content_text
 
         node.marker = root.get('marker')
         if node.marker == 'none':

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -10,7 +10,8 @@ from regulation.tree import (build_reg_tree,
                              build_paragraph_marker_layer,
                              build_interp_layer,
                              build_analysis,
-                             build_notice)
+                             build_notice,
+                             build_formatting_layer)
 from regulation.node import RegNode
 
 
@@ -54,7 +55,6 @@ class TreeTestCase(TestCase):
                 '1234-1': [{u'reference': '1234-1-Interp'}], 
                 '1234-1-A': [{u'reference': '1234-1-A-Interp'}], 
         }
-        print(dict(interp_dict))
         self.assertEqual(expected_result, interp_dict)
 
     def test_build_analysis(self):
@@ -181,4 +181,58 @@ class TreeTestCase(TestCase):
         result = reg_tree.height()
 
         self.assertEqual(result, 4)
+
+    def test_build_formatting_layer_variable(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs">
+          <paragraph label="foo">
+            <content>
+              <variable>Val<subscript>n</subscript></variable>
+            </content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            'foo': [{
+                'locations': [0], 
+                'subscript_data': {
+                    'subscript': 'n', 
+                    'variable': 'Val'
+                }, 
+                'text': 'Val_{n}'
+            }]
+        }
+        result = build_formatting_layer(tree)
+        self.assertEqual(expected_result, result)
+
+    def test_build_formatting_layer_callout(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs">
+          <paragraph label="foo">
+            <content>
+              <callout type="note">
+                <line>Note:</line>
+                <line>Some notes</line>
+              </callout>
+            </content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            'foo': [{
+                'fence_data': {
+                    'lines': [
+                        'Note:', 
+                        'Some notes'
+                    ], 
+                    'type': 'note'
+                }, 
+                'locations': [
+                    0
+                ], 
+                'text': '```note\nNote:\nSome notes\n```'
+            }]
+        }
+        result = build_formatting_layer(tree)
+        self.assertEqual(expected_result, result)
 


### PR DESCRIPTION
This PR adds support for `variable`/`subscript` and `callout` elements. 

Variables are values that have subscripts that should be rendered as a formatting layer to be handled by reg-site. 

![image](https://cloud.githubusercontent.com/assets/10562538/13077984/4b97eef6-d48a-11e5-8b77-a603ca69473c.png)

Callouts are rendered via the formatting layer as either callout-box notes or code blocks by reg-site.

![image](https://cloud.githubusercontent.com/assets/10562538/13078012/817c5e1c-d48a-11e5-906c-6ce5c8d0a3c9.png)

![image](https://cloud.githubusercontent.com/assets/10562538/13078019/907eb324-d48a-11e5-8ad8-49f38aefe90e.png)

This PR also includes a fix for body-text key-term titles. They should now always be displayed when the RegML is Correct™ and doesn’t include them in the content as well as the title element.
