### PR TITLE
Add Interp fixer

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -246,6 +246,26 @@ def check_terms(file, label=None):
             label=label)
 
 
+@cli.command()
+@click.argument('file')
+@click.option('--label')
+def check_interp_targets(file, label=None):
+    """ Check the interpretations targets in a RegML file """
+
+    file = find_file(file)
+    with open(file, 'r') as f:
+        reg_xml = f.read()
+    xml_tree = etree.fromstring(reg_xml)
+
+    if xml_tree.tag == '{eregs}notice':
+        print("Cannot check terms in notice files")
+        sys.exit(1)
+
+    # Validate the file relative to schema
+    validator = get_validator(xml_tree)
+    validator.validate_interp_targets(xml_tree, file, label=label)
+    
+
 # Validate the given regulation file (or files) and generate the JSON
 # output expected by regulations-core and regulations-site if the RegML
 # validates.

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -64,12 +64,13 @@ def build_reg_tree(root, parent=None, depth=0):
         children = root.findall('{eregs}paragraph')
 
     elif tag == 'paragraph':
-
         title = root.find('{eregs}title')
         content = root.find('{eregs}content')
         content_text = xml_node_text(content)
-        if title is not None and title.get('type') != 'keyterm':
+
+        if title is not None:
             node.title = title.text
+
         node.marker = root.get('marker')
         if node.marker == 'none':
             marker = ''
@@ -150,6 +151,7 @@ def build_reg_tree(root, parent=None, depth=0):
         content_text = xml_node_text(content)
         if title is not None:
             node.title = title.text
+
         node.marker = root.get('marker', '')
         if node.marker == 'none':
             node.marker = ''

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -322,7 +322,10 @@ def build_formatting_layer(root):
         content = paragraph.find('{eregs}content')
         dashes = content.findall('.//{eregs}dash')
         tables = content.findall('.//{eregs}table')
+        variables = content.findall('.//{eregs}variable')
+        callouts = content.findall('.//{eregs}callout')
         label = paragraph.get('label')
+
         if len(dashes) > 0:
             layer_dict[label] = []
             for dash in dashes:
@@ -334,6 +337,37 @@ def build_formatting_layer(root):
                 dash_dict['dash_data'] = {'text': dash_text}
                 dash_dict['locations'] = [0]
                 layer_dict[label].append(dash_dict)
+
+        if len(variables) > 0:
+            if label not in layer_dict:
+                layer_dict[label] = []
+
+            for variable in variables:
+                subscript = variable.find('{eregs}subscript')
+                var_dict = OrderedDict()
+                var_dict['subscript_data'] = {
+                    'variable': variable.text,
+                    'subscript': subscript.text,
+                }
+                var_dict['locations'] = [0]
+                var_dict['text'] = ''
+                layer_dict[label].append(var_dict)
+
+        if len(callouts) > 0:
+            if label not in layer_dict:
+                layer_dict[label] = []
+
+            for callout in callouts:
+                lines = callout.findall('{eregs}line')
+                callout_dict = OrderedDict()
+                callout_dict['fence_data'] = {
+                    'lines': [l.text for l in lines],
+                    'type': callout.get('type')
+                }
+                callout_dict['locations'] = [0]
+                callout_dict['text'] = ''
+                layer_dict[label].append(callout_dict)
+
         if len(tables) > 0:
             if label not in layer_dict:
                 layer_dict[label] = []

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -69,7 +69,12 @@ def build_reg_tree(root, parent=None, depth=0):
         content_text = xml_node_text(content)
 
         if title is not None:
-            node.title = title.text
+            if title.get('type') != 'keyterm':
+                node.title = title.text
+            else:
+                # Keyterms are expected by reg-site to be included in
+                # the content text rather than the title of a node.
+                content_text = title.text + content_text
 
         node.marker = root.get('marker')
         if node.marker == 'none':

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -433,3 +433,129 @@ class EregsValidator:
             if error.severity != Severity.OK:
                 return False
         return True
+
+    def validate_interp_targets(self, tree, regulation_file, label=None):
+        """ Validate interpretation targets within a given label with
+            the option to write corrected targets out to the
+            regulation_file. """
+            
+        problem_flag = False
+
+        # Pick out our working section of the tree. If no label was
+        # given, we're working on the interpretations node in the tree.
+        if label is not None:
+            working_section = tree.find(
+                    './/*[@label="{}"]'.format(label))
+            if working_section.tag not in (
+                    '{eregs}interpretations',
+                    '{eregs}interpSection', 
+                    '{eregs}interpParagraph'):
+                print("{} is not a part of an interpretation".format(
+                    label))
+                return 
+        else:
+            working_section = tree.find('.//{eregs}interpretations')
+
+        # Find all paragraphs with a target attribute
+        paragraphs = working_section.findall(
+                './/{eregs}interpParagraph[@target]')
+
+        for paragraph in paragraphs:
+            target = paragraph.get('target')
+            label = paragraph.get('label')
+            
+            # If the label doesn't end with '-Interp' it shouldn't have
+            # a target.
+            if not label.endswith('-Interp') and target is not None:
+                problem_flag = True
+                print(colored('Removing bad target {} in {}'.format(
+                        target, label), 'yellow'))
+                del paragraph.attrib['target']
+                continue
+
+            # Break down the label and figure out the paragraph the
+            # paragraph should be assigned to. If it doesn't match the
+            # target, it's a bad target.
+            label_target = label[:label.find('-Interp')]
+            if label_target != target:
+                problem_flag = True
+                print(colored('Fixing bad target {} in {}'.format(
+                        target, label), 'yellow'))
+                paragraph.set('target', label_target)
+                continue
+
+            print(colored('Leaving good target {} in {}'.format(
+                    target, label), 'green'))
+
+        if problem_flag:
+            print(colored('The tree has been altered! Do you want to' 
+                'write the result to disk?', 'red'))
+            answer = None
+            while answer not in ['y', 'n']:
+                answer = raw_input('Save? y/n: ')
+            if answer == 'y':
+                with open(regulation_file, 'w') as f:
+                    f.write(etree.tostring(tree, pretty_print=True))
+
+    def validate_interp_targets(self, tree, regulation_file, label=None):
+        """ Validate interpretation targets within a given label with
+            the option to write corrected targets out to the
+            regulation_file. """
+            
+        problem_flag = False
+
+        # Pick out our working section of the tree. If no label was
+        # given, we're working on the interpretations node in the tree.
+        if label is not None:
+            working_section = tree.find(
+                    './/*[@label="{}"]'.format(label))
+            if working_section.tag not in (
+                    '{eregs}interpretations',
+                    '{eregs}interpSection', 
+                    '{eregs}interpParagraph'):
+                print("{} is not a part of an interpretation".format(
+                    label))
+                return 
+        else:
+            working_section = tree.find('.//{eregs}interpretations')
+
+        # Find all paragraphs with a target attribute
+        paragraphs = working_section.findall(
+                './/{eregs}interpParagraph[@target]')
+
+        for paragraph in paragraphs:
+            target = paragraph.get('target')
+            label = paragraph.get('label')
+            
+            # If the label doesn't end with '-Interp' it shouldn't have
+            # a target.
+            if not label.endswith('-Interp') and target is not None:
+                problem_flag = True
+                print(colored('Removing bad target {} in {}'.format(
+                        target, label), 'yellow'))
+                del paragraph.attrib['target']
+                continue
+
+            # Break down the label and figure out the paragraph the
+            # paragraph should be assigned to. If it doesn't match the
+            # target, it's a bad target.
+            label_target = label[:label.find('-Interp')]
+            if label_target != target:
+                problem_flag = True
+                print(colored('Fixing bad target {} in {}'.format(
+                        target, label), 'yellow'))
+                paragraph.set('target', label_target)
+                continue
+
+            print(colored('Leaving good target {} in {}'.format(
+                    target, label), 'green'))
+
+        if problem_flag:
+            print(colored('The tree has been altered! Do you want to' 
+                'write the result to disk?', 'red'))
+            answer = None
+            while answer not in ['y', 'n']:
+                answer = raw_input('Save? y/n: ')
+            if answer == 'y':
+                with open(regulation_file, 'w') as f:
+                    f.write(etree.tostring(tree, pretty_print=True))

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -10,7 +10,8 @@ from regulation.tree import (build_reg_tree,
                              build_paragraph_marker_layer,
                              build_interp_layer,
                              build_analysis,
-                             build_notice)
+                             build_notice,
+                             build_formatting_layer)
 from regulation.node import RegNode
 
 
@@ -54,7 +55,6 @@ class TreeTestCase(TestCase):
                 '1234-1': [{u'reference': '1234-1-Interp'}], 
                 '1234-1-A': [{u'reference': '1234-1-A-Interp'}], 
         }
-        print(dict(interp_dict))
         self.assertEqual(expected_result, interp_dict)
 
     def test_build_analysis(self):
@@ -181,4 +181,58 @@ class TreeTestCase(TestCase):
         result = reg_tree.height()
 
         self.assertEqual(result, 4)
+
+    def test_build_formatting_layer_variable(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs">
+          <paragraph label="foo">
+            <content>
+              <variable>Val<subscript>n</subscript></variable>
+            </content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            'foo': [{
+                'locations': [0], 
+                'subscript_data': {
+                    'subscript': 'n', 
+                    'variable': 'Val'
+                }, 
+                'text': 'Val_{n}'
+            }]
+        }
+        result = build_formatting_layer(tree)
+        self.assertEqual(expected_result, result)
+
+    def test_build_formatting_layer_callout(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs">
+          <paragraph label="foo">
+            <content>
+              <callout type="note">
+                <line>Note:</line>
+                <line>Some notes</line>
+              </callout>
+            </content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            'foo': [{
+                'fence_data': {
+                    'lines': [
+                        'Note:', 
+                        'Some notes'
+                    ], 
+                    'type': 'note'
+                }, 
+                'locations': [
+                    0
+                ], 
+                'text': '```note\nNote:\nSome notes\n```'
+            }]
+        }
+        result = build_formatting_layer(tree)
+        self.assertEqual(expected_result, result)
 


### PR DESCRIPTION
This adds an interactive tool to fix interpretations targets.

```
./regml.py check_interp_targets 1026/2011-31715 --label 1026-3-Interp
```

Will go through each interpSection/interpParagrah in 1026-3-Interp and verify that the target is appropriately set.
