### PR TITLE
Match reg-site's expectations of intro paragraphs

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -56,13 +56,26 @@ def build_reg_tree(root, parent=None, depth=0):
 
     elif tag == 'section' and root.attrib != {}:
         subject = root.find(ns_prefix + 'subject')
-        # print root, parent.node_type, subject.text
         label = root.get('label').split('-')
         node.title = subject.text
         node.node_type = 'regtext'
         node.label = label
 
         children = root.findall('{eregs}paragraph')
+
+        # Check to see if the first child is an unmarked intro
+        # paragraph. Reg-site expects those to be be the 'text' of this
+        # node rather than child nodes in their own right.
+        if len(children) > 0:
+            first_child = children[0]
+            # if it doesn't have a title, doesn't have a marker, and
+            # doesn't have children, it is an intro paragraph.
+            if first_child.find('{eregs}title') is None and \
+                    first_child.get('marker') in ('', 'none') and \
+                    len(first_child.findall('{eregs}paragraph')) == 0:
+                content = xml_node_text(first_child.find('{eregs}content'))
+                node.text = content.strip()
+                del children[0]
 
     elif tag == 'paragraph':
         title = root.find('{eregs}title')
@@ -96,6 +109,8 @@ def build_reg_tree(root, parent=None, depth=0):
         node.source_xml = etree.tostring(root, encoding='UTF-8')
 
         children = root.findall('{eregs}paragraph')
+
+        # If the title, 
 
     elif tag == 'appendix':
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -220,7 +220,12 @@ def build_internal_citations_layer(root):
         else:
             marker_offset = 0
 
-        if title is not None and title.get('type') == 'keyterm':
+        # Keyterm offset.
+        # Note: reg-site treats interp-paragraphs as "special" — they
+        # don't get the keyterm text included, so we don't include an
+        # offset here.
+        if title is not None and title.get('type') == 'keyterm' and \
+                paragraph.tag != '{eregs}interpParagraph':
             keyterm_offset = len(title.text)
         else:
             keyterm_offset = 0
@@ -556,7 +561,12 @@ def build_terms_layer(root):
         else:
             marker_offset = 0
 
-        if title is not None and title.get('type') == 'keyterm':
+        # Keyterm offset.
+        # Note: reg-site treats interp-paragraphs as "special" — they
+        # don't get the keyterm text included, so we don't include an
+        # offset here.
+        if title is not None and title.get('type') == 'keyterm' and \
+                paragraph.tag != '{eregs}interpParagraph':
             keyterm_offset = len(title.text)
         else:
             keyterm_offset = 0
@@ -592,8 +602,6 @@ def build_terms_layer(root):
             if len(ref_dict['offsets']) > 0 and \
                     ref_dict not in terms_dict[label]:
                 terms_dict[label].append(ref_dict)
-
-
 
     terms_dict['referenced'] = definitions_dict
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -71,7 +71,7 @@ def build_reg_tree(root, parent=None, depth=0):
             # if it doesn't have a title, doesn't have a marker, and
             # doesn't have children, it is an intro paragraph.
             if first_child.find('{eregs}title') is None and \
-                    first_child.get('marker') in ('', 'none') and \
+                    first_child.get('marker') == '' and \
                     len(first_child.findall('{eregs}paragraph')) == 0:
                 content = xml_node_text(first_child.find('{eregs}content'))
                 node.text = content.strip()
@@ -229,6 +229,13 @@ def build_internal_citations_layer(root):
             paragraph.find('{eregs}content'))).strip()
 
         par_label = paragraph.get('label')
+        if paragraph.getparent().tag == '{eregs}section' and \
+                paragraph.find('{eregs}title') is None and \
+                paragraph.get('marker') == '' and \
+                len(paragraph.findall('{eregs}paragraph')) == 0:
+            # This paragraph will get attached to its parent node by
+            # build_reg_text
+            par_label = paragraph.getparent().get('label')
 
         if marker != '' and paragraph.tag != '{eregs}interpParagraph':
             marker_offset = len(marker + ' ')
@@ -560,8 +567,16 @@ def build_terms_layer(root):
         content = paragraph.find('{eregs}content')
         terms = content.findall('.//{eregs}ref[@reftype="term"]')
         title = paragraph.find('{eregs}title')
-        label = paragraph.get('label')
         marker = paragraph.get('marker') or ''
+
+        label = paragraph.get('label')
+        if paragraph.getparent().tag == '{eregs}section' and \
+                paragraph.find('{eregs}title') is None and \
+                paragraph.get('marker') == '' and \
+                len(paragraph.findall('{eregs}paragraph')) == 0:
+            # This paragraph will get attached to its parent node by
+            # build_reg_text
+            label = paragraph.getparent().get('label')
 
         if len(terms) > 0:
             terms_dict[label] = []
@@ -607,8 +622,6 @@ def build_terms_layer(root):
             if len(ref_dict['offsets']) > 0 and \
                     ref_dict not in terms_dict[label]:
                 terms_dict[label].append(ref_dict)
-
-
 
     terms_dict['referenced'] = definitions_dict
 

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -268,4 +268,40 @@ class TreeTestCase(TestCase):
         result = apply_formatting(content)
         self.assertEqual(expected_result.text.strip(), result.text)
 
+    def test_build_reg_tree_intro_para(self):
+        tree = etree.fromstring("""
+        <section label="foo" xmlns="eregs">
+          <subject>Some Subject</subject>
+          <paragraph label="foo-p1" marker="none">
+            <content>
+              An unmarked intro paragraph.
+            </content>
+          </paragraph>
+          <paragraph label="foo-a" marker="a">
+            <content>A marked paragraph</content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            'children': [
+                {
+                    'children': [], 
+                    'label': [
+                        'foo', 
+                        'a'
+                    ], 
+                    'node_type': 'regtext', 
+                    'text': 'a A marked paragraph', 
+                    'marker': 'a'
+                }
+            ], 
+            'label': [
+                'foo'
+            ], 
+            'node_type': 'regtext', 
+            'text': 'An unmarked intro paragraph.', 
+            'title': 'Some Subject'
+        }
+        result = build_reg_tree(tree)
+        self.assertEqual(expected_result, result.to_json())
 

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -272,7 +272,7 @@ class TreeTestCase(TestCase):
         tree = etree.fromstring("""
         <section label="foo" xmlns="eregs">
           <subject>Some Subject</subject>
-          <paragraph label="foo-p1" marker="none">
+          <paragraph label="foo-p1" marker="">
             <content>
               An unmarked intro paragraph.
             </content>

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -149,9 +149,9 @@ class TreeTestCase(TestCase):
         result = reg_tree.find_node(predicate)
 
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].string_label, '1234-1-p1')
+        self.assertEqual(result[0].string_label, '1234-1')
         self.assertEqual(result[0].text, "I'm an unmarked paragraph")
-        self.assertEqual(result[0].marker, "")
+        self.assertEqual(result[0].marker, None)
         self.assertEqual(result[1].string_label, '1234-1-a')
         self.assertEqual(result[1].text, "a I'm a marked paragraph")
         self.assertEqual(result[1].marker, "a")


### PR DESCRIPTION
This PR changes section child paragraph handling slightly so that the output will match reg-site’s expectation of unmarked intro paragraphs. 

Reg-site expects sections that have an unmarked intro paragraphs will have that paragraph content attached to as `text` to the section node, rather than as a child node. 

The expected output is illustrated in the test case.

@grapesmoker @hillaryj 
