### PR TITLE
Fix keyterm offset interps

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -220,7 +220,12 @@ def build_internal_citations_layer(root):
         else:
             marker_offset = 0
 
-        if title is not None and title.get('type') == 'keyterm':
+        # Keyterm offset.
+        # Note: reg-site treats interp-paragraphs as "special" — they
+        # don't get the keyterm text included, so we don't include an
+        # offset here.
+        if title is not None and title.get('type') == 'keyterm' and \
+                paragraph.tag != '{eregs}interpParagraph':
             keyterm_offset = len(title.text)
         else:
             keyterm_offset = 0
@@ -556,7 +561,12 @@ def build_terms_layer(root):
         else:
             marker_offset = 0
 
-        if title is not None and title.get('type') == 'keyterm':
+        # Keyterm offset.
+        # Note: reg-site treats interp-paragraphs as "special" — they
+        # don't get the keyterm text included, so we don't include an
+        # offset here.
+        if title is not None and title.get('type') == 'keyterm' and \
+                paragraph.tag != '{eregs}interpParagraph':
             keyterm_offset = len(title.text)
         else:
             keyterm_offset = 0
@@ -592,8 +602,6 @@ def build_terms_layer(root):
             if len(ref_dict['offsets']) > 0 and \
                     ref_dict not in terms_dict[label]:
                 terms_dict[label].append(ref_dict)
-
-
 
     terms_dict['referenced'] = definitions_dict
 


### PR DESCRIPTION
Slight fix for #9. 

Keyterms in interpretations are expected to be different in from everything else. Everywhere else, the keyterm is included in the paragraph content at the beginning, so we need an offset when applying terms and citations. Interpretations don’t do that — the key term text isn’t included in the content, so we don’t need the offset.

**Review**
@grapesmoker @hillaryj 
