### PR TITLE
Allow user to specify single term to check for 

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -225,7 +225,8 @@ def validate(file, no_terms=False, no_citations=False, no_keyterms=False):
 @cli.command('check-terms')
 @click.argument('file')
 @click.option('--label')
-def check_terms(file, label=None):
+@click.option('--term')
+def check_terms(file, label=None, term=None):
     """ Check the terms in a RegML file """
 
     file = find_file(file)
@@ -243,7 +244,7 @@ def check_terms(file, label=None):
     terms = build_terms_layer(xml_tree)
     validator.validate_terms(xml_tree, terms)
     validator.validate_term_references(xml_tree, terms, file,
-            label=label)
+            label=label, term=term)
 
 
 @cli.command()

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -235,18 +235,28 @@ class EregsValidator:
         self.events.append(event)
 
     def validate_term_references(self, tree, terms_layer,
-            regulation_file, label=None):
+            regulation_file, label=None, term=None):
         """ Validate term references. If label is given, only validate
-            term references within that label. """
+            term references within that label. If term is given, only
+            validate references to that term. """
 
         problem_flag = False
         inf = inflect.engine()
 
         definitions = terms_layer['referenced']
-        terms = set([(defn['term'], defn['reference']) for key, defn in definitions.iteritems()])
+        terms = set([(defn['term'], defn['reference']) for key, defn in definitions.items()])
         cap_terms = set([(defn['term'][0].upper() + defn['term'][1:], defn['reference'])
                      for key, defn in definitions.iteritems()])
         terms = terms | cap_terms
+        if term is not None:
+            try:
+                reference = next((defn['reference'] for key, defn in
+                    definitions.items() if defn['term'] == term))
+            except StopIteration:
+                print(colored("{} is not a defined term".format(term),
+                    'red'))
+                return
+            terms = set([(term, term[0].upper() + term[1:], reference)])
 
         # Pick out our working section of the tree. If no label was
         # given, it *is* the tree.

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -253,7 +253,6 @@ class EregsValidator:
             try:
                 reference = next((defn['reference'] for key, defn in
                     definitions.items() if defn['term'] == term))
-                print(reference)
             except StopIteration:
                 print(colored("{} is not a defined term".format(term),
                     'red'))
@@ -308,7 +307,6 @@ class EregsValidator:
                                         input_state = raw_input('(y)es/(n)o/(i)gnore this term/(a)lways correct: ')
 
                                 if input_state in ['y', 'a'] or term[0] in always:
-                                    import pdb; pdb.set_trace()
                                     problem_flag = True
                                     ref = '<ref target="{}" reftype="term">{}</ref>'.format(term[1], term_to_use)
                                     offsets_and_values.append((ref, [term_loc, term_loc + len(term_to_use)]))

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -253,11 +253,13 @@ class EregsValidator:
             try:
                 reference = next((defn['reference'] for key, defn in
                     definitions.items() if defn['term'] == term))
+                print(reference)
             except StopIteration:
                 print(colored("{} is not a defined term".format(term),
                     'red'))
                 return
-            terms = set([(term, term[0].upper() + term[1:], reference)])
+            terms = set([(term, reference), 
+                         (term[0].upper() + term[1:], reference)])
 
         # Pick out our working section of the tree. If no label was
         # given, it *is* the tree.
@@ -306,6 +308,7 @@ class EregsValidator:
                                         input_state = raw_input('(y)es/(n)o/(i)gnore this term/(a)lways correct: ')
 
                                 if input_state in ['y', 'a'] or term[0] in always:
+                                    import pdb; pdb.set_trace()
                                     problem_flag = True
                                     ref = '<ref target="{}" reftype="term">{}</ref>'.format(term[1], term_to_use)
                                     offsets_and_values.append((ref, [term_loc, term_loc + len(term_to_use)]))

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 from enum import Enum
@@ -272,7 +273,8 @@ class EregsValidator:
 
         for paragraph in paragraphs:
             content = paragraph.find('.//{eregs}content')
-            par_text = etree.tostring(content, encoding='UTF-8')
+            par_text = unicode(etree.tostring(content,
+                encoding='UTF-8'))
             label = paragraph.get('label')
             offsets_and_values = []
 


### PR DESCRIPTION
This PR adds an option to the term checker to take a single term. If that term is given, the term checker will only check for instances of that term, rather than all defined terms.
