### PR TITLE
Generate left document numbers in changesets

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -422,7 +422,8 @@ def ecfr(title, file, act_title, act_section,
                                      layer_cache)
 
     # Do the first version
-    print("Version %s", builder.doc_number)
+    last_version = builder.doc_number
+    print("Version {}".format(last_version))
     if (only_notice is not None and builder.doc_number == only_notice) \
             or only_notice is None:
         if not without_versions:
@@ -431,7 +432,7 @@ def ecfr(title, file, act_title, act_section,
     for last_notice, old, new_tree, notices in builder.revision_generator(
             reg_tree):
         version = last_notice['document_number']
-        print("Version", version)
+        print("Version {}".format(version))
         builder.doc_number = version
         layers = builder.generate_layers(new_tree,
                                          [act_title, act_section],
@@ -445,9 +446,11 @@ def ecfr(title, file, act_title, act_section,
                 builder.write_notice(version,
                                      old_tree=old,
                                      reg_tree=new_tree,
-                                     layers=layers)
+                                     layers=layers,
+                                     last_version=last_version)
         layer_cache.invalidate_by_notice(last_notice)
         layer_cache.replace_using(new_tree)
+        last_version = version
         del last_notice, old, new_tree, notices     # free some memory
 
 


### PR DESCRIPTION
This PR makes a minor change to the way regml.py calls the eCFR parser. It now passes the last version id to `write_notice`, which will ensure that `leftDocumentNumber` is correct in the notice `changeset` element.
