### PR TITLE
Ensure 'added' nodes don't already exist

### DIFF
--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -126,6 +126,13 @@ def process_changes(original_xml, notice_xml, dry=False):
             new_elm = change.getchildren()[0]
             new_index = 0
 
+            # First make sure the label doesn't already exist
+            matching_elm = new_xml.find('.//*[@label="{}"]'.format(label))
+            if matching_elm is not None:
+                raise KeyError("Label {} cannot be added because it "
+                               "already exists. Was it added in another "
+                               "change?".format(label))
+
             # Get the parent of the added label
             parent_label = '-'.join(get_parent_label(label_parts))
             parent_elm = new_xml.find('.//*[@label="{}"]'.format(parent_label))

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -118,6 +118,28 @@ class ChangesTests(TestCase):
         self.assertNotEqual(new_para, None)
         self.assertEqual("An added paragraph", new_para.text)
 
+    def test_process_changes_added_existing(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="added" label="1234-2">
+                  <paragraph label="1234-2">An added paragraph</paragraph>
+                </change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <paragraph label="1234-1">An existing paragraph</paragraph>
+                <paragraph label="1234-2">Another existing paragraph</paragraph>
+              </part>
+            </regulation>""")
+        with self.assertRaises(KeyError):
+            process_changes(original_xml, notice_xml)
+
     def test_process_changes_modified(self):
         notice_xml = etree.fromstring("""
             <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">


### PR DESCRIPTION
This PR adds a check to change processing to ensure that a label that’s being “added” doesn’t already exist.

This can happen if there is a modification to the parent label _and_ a child is added as two separate changes in the notice file.
