### PR TITLE
Handle top-level interpretations

### DIFF
--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -78,7 +78,7 @@ def get_sibling_label(label_parts):
 
     if len(sibling_label) != len(label_parts):
         # We weren't able to find the last part in the marker levels? So
-        # there is no proceeding sibling.
+        # there is no preceding sibling.
         return None
 
     return sibling_label

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -26,6 +26,10 @@ def get_parent_label(label_parts):
     if len(label_parts) <= 1:
         return parent_label
 
+    # If it's the interps for the whole part, return the part
+    if len(label_parts) == 2:
+        return label_parts[:1]
+
     # Not an interpretation label. This is easy.
     parent_label = label_parts[0:-1]
 
@@ -73,9 +77,9 @@ def get_sibling_label(label_parts):
         sibling_label.append('Interp')
 
     if len(sibling_label) != len(label_parts):
-        # We weren't able to find the last part in the marker levels?
-        raise IndexError("Unable to locate sibling for '{}'".format(
-            last_part))
+        # We weren't able to find the last part in the marker levels? So
+        # there is no proceeding sibling.
+        return None
 
     return sibling_label
 
@@ -107,7 +111,12 @@ def process_changes(original_xml, notice_xml, dry=False):
         './/{eregs}change[@operation="added"]')
 
     # Sort them appropriately by label
-    get_label = lambda c: c.get('label')
+    # Note: Interp labels are special. For comparison purposes, we just
+    # remove the '-Interp' from the label. Otherwse we would end up with
+    # something like '1234-Interp' being sorted after '1234-1-Interp'.
+    get_label = lambda c: c.get('label') \
+                          if 'Interp' not in c.get('label') \
+                          else c.get('label').replace('-Interp', '')
     deletions = list(reversed(sorted(deletions, key=get_label)))
     modifications = list(reversed(sorted(modifications, key=get_label)))
     additions = list(sorted(additions, key=get_label))
@@ -146,6 +155,10 @@ def process_changes(original_xml, notice_xml, dry=False):
 
                 # Figure out where we're inserting this element
                 new_index = parent_elm.index(sibling_elm) + 1
+            else:
+                # If the sibling label is none, just append it to the
+                # end of the parent.
+                new_index = len(parent_elm.getchildren())
 
             # Insert it!
             if not dry:

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -28,6 +28,11 @@ class ChangesTests(TestCase):
         self.assertEqual(['1234', '1', 'g', '2', 'Interp'],
                          get_parent_label(label_parts))
 
+    def test_get_parent_label_part_interp(self):
+        label_parts = ['1234', 'Interp']
+        self.assertEqual(['1234', ],
+                         get_parent_label(label_parts))
+        
     def test_get_sibling_label_alpha(self):
         label_parts = ['1234', '1', 'g']
         self.assertEqual(['1234', '1', 'f'],
@@ -43,6 +48,10 @@ class ChangesTests(TestCase):
         self.assertEqual(['1234', '1', 'g', '1', 'Interp'],
                          get_sibling_label(label_parts))
 
+    def test_get_sibling_label_part_interp(self):
+        label_parts = ['1234', 'Interp']
+        self.assertEqual(None, get_sibling_label(label_parts))
+        
     def test_get_sibling_label_none(self):
         label_parts = ['1234', '1', 'a']
         self.assertEqual(None, get_sibling_label(label_parts))
@@ -139,6 +148,32 @@ class ChangesTests(TestCase):
             </regulation>""")
         with self.assertRaises(KeyError):
             process_changes(original_xml, notice_xml)
+
+    def test_process_changes_added_interp(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="added" label="1234-Interp">
+                  <interpretations label="1234-Interp">
+                    <title>Supplement I to Part 1234</title>
+                  </interpretations>
+                </change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <subpart></subpart>
+                <appendix label="1234-A"></appendix>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        new_interp = new_xml.find('.//{eregs}interpretations[@label="1234-Interp"]')
+        self.assertNotEqual(new_interp, None)
+        self.assertEqual(new_interp.getparent().index(new_interp), 2)
 
     def test_process_changes_modified(self):
         notice_xml = etree.fromstring("""


### PR DESCRIPTION
This PR updates the parent/sibling discovery and handling for when we’re adding top-level interpretations (labels like “1234-Interp”). 

This will have `get_parent_label()` return the part number (“1234”) and `get_sibling_label()` return `None` instead of raising an `IndexError`. Then, if the sibling label is `None`, the added element will be appended to the end of the parent element.

Updated unit tests are included.
