### PR TITLE
extend unmarked intro paragraph trick to appendices; titleize interps 

### DIFF
--- a/regulation/node.py
+++ b/regulation/node.py
@@ -9,8 +9,13 @@ import re
 import json
 import hashlib
 
-class RegNode:
 
+class RegNode:
+    """
+    The RegNode class represents a regular text node in a regulation.
+    It provides for some convenience functions for manipulating the
+    tree hierarchy if necessary.
+    """
     def __init__(self, **kwargs):
         self.label = []
         self.marker = None
@@ -33,6 +38,11 @@ class RegNode:
             self.include_children = False
 
     def to_json(self):
+        """
+        Convert yourself, and possibly all your children, into JSON.
+        :return: A dict representing the node, suitable for direct
+        use wherever JSON is expected.
+        """
         node_dict = OrderedDict()
 
         if self.include_children:
@@ -112,7 +122,6 @@ class RegNode:
 
         return matches
 
-
     def flatten(self):
         """
         Return this node and all its children in a flat list
@@ -148,9 +157,6 @@ class RegNode:
         :return:
         """
 
-        import pdb
-        #pdb.set_trace()
-
         if self.children == []:
             return [self.string_label]
         else:
@@ -171,6 +177,12 @@ class RegNode:
 
 
 def xml_node_text(node, include_children=True):
+    """
+
+    :param node:
+    :param include_children:
+    :return:
+    """
 
     if node.text:
         node_text = node.text

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -134,6 +134,20 @@ def build_reg_tree(root, parent=None, depth=0):
 
         children = root.findall('{eregs}paragraph')
 
+        # Check to see if the first child is an unmarked intro
+        # paragraph. Reg-site expects those to be be the 'text' of this
+        # node rather than child nodes in their own right.
+        if len(children) > 0:
+            first_child = children[0]
+            # if it doesn't have a title, doesn't have a marker, and
+            # doesn't have children, it is an intro paragraph.
+            if first_child.find('{eregs}title') is None and \
+                    first_child.get('marker') == '' and \
+                    len(first_child.findall('{eregs}paragraph')) == 0:
+                content = xml_node_text(first_child.find('{eregs}content'))
+                node.text = content.strip()
+                del children[0]
+
     elif tag == 'interpretations':
 
         title = root.find('{eregs}title')

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -453,7 +453,6 @@ class EregsValidator:
                 with open(regulation_file, 'w') as f:
                     f.write(etree.tostring(tree, pretty_print=True))
 
-
     def headerize_interps(self, tree, regulation_file):
         paragraphs = tree.findall('.//{eregs}interpParagraph')
         change_flag = False
@@ -470,27 +469,40 @@ class EregsValidator:
                 print(colored(current_par, 'yellow'))
                 response = None
                 while response not in ['y', 'n']:
-                    msg = colored('Do you want to titleize this paragraph?')
+                    msg = colored('Do you want to titleize this paragraph?', 'red')
                     print(msg)
                     response = raw_input('(y)es/(n)o: ')
                 if response.lower() == 'y':
+                    #import ipdb; ipdb.set_trace()
                     response = None
-                    content_text = content.text
-                    first_period = content_text.find('.')
+                    content_text = etree.tostring(content)
+                    first_angle = content_text.find('>')
+                    close_content = content_text.find('</content>')
+                    remainder = content_text[first_angle + 1:close_content]
+                    first_period = remainder.find('.')
                     if first_period > -1:
-                        title_string = content_text[:first_period + 1]
+                        title_string = remainder[:first_period + 1]
                         new_title = '<title>' + title_string + '</title>'
-                        new_text = '<content>' + xml_node_text(content).replace(title_string, '').strip() + '</content>'
+                        elem = etree.fromstring(new_title)
+                        new_title = '<title>' + xml_node_text(elem) + '</title>'
+                        new_text = '<content>' + remainder.replace(title_string, '').strip() + '</content>'
                         paragraph.insert(0, etree.fromstring(new_title))
-
-                        #new_paragraph = '<interpParagraph label="{}" target="{}" marker="{}">\n'.format(label, target, marker)
-                        #new_paragraph += new_title + '\n'
-                        #new_paragraph += new_text + '\n</interpParagraph>'
-                        #print(colored(new_paragraph, 'green'))
-
+                        paragraph.replace(content, etree.fromstring(new_text))
+                        new_paragraph = '<interpParagraph label="{}" target="{}" marker="{}">\n'.format(label, target, marker)
+                        new_paragraph += new_title + '\n'
+                        new_paragraph += new_text + '\n</interpParagraph>'
+                        print(colored(new_paragraph, 'green'))
                         change_flag = True
                     else:
                         print(colored('Nothing to headerize!', 'red'))
+        if change_flag:
+            print(colored('The tree has been altered! Do you want to write the result to disk?', 'red'))
+            answer = None
+            while answer not in ['y', 'n']:
+                answer = raw_input('Save? y/n: ')
+            if answer == 'y':
+                with open(regulation_file, 'w') as f:
+                    f.write(etree.tostring(tree, pretty_print=True, encoding='UTF-8'))
 
     def insert_interp_markers(self, tree, regulation_file):
         """ Add in the markers for interp paragraphs in situations where 


### PR DESCRIPTION
This PR appends unmaked intro paragraph text to the section node for appendices just like it does for regtext. It also adds capability to the validator to titleize interps with user interaction.
