### PR TITLE
Add "moved" operation

### DIFF
--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -61,6 +61,11 @@ def get_parent_label(label_parts):
         parent_label = get_parent_label(parent_label)
         parent_label.append('Interp')
 
+    # Subparts are also special and their parent should be the label 
+    # until the "Subpart" portion
+    if "Subpart" in label_parts:
+        parent_label = label_parts[:label_parts.index("Subpart")]
+
     return parent_label
 
 

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -33,6 +33,11 @@ class ChangesTests(TestCase):
         self.assertEqual(['1234', ],
                          get_parent_label(label_parts))
         
+    def test_get_parent_label_part_subpart(self):
+        label_parts = ['1234', 'Subpart', 'A']
+        self.assertEqual(['1234', ],
+                         get_parent_label(label_parts))
+        
     def test_get_sibling_label_alpha(self):
         label_parts = ['1234', '1', 'g']
         self.assertEqual(['1234', '1', 'f'],

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -219,6 +219,90 @@ class ChangesTests(TestCase):
         del_paras = new_xml.findall('.//{eregs}paragraph[@label="1234-1"]')
         self.assertEqual(len(del_paras), 0)
 
+    def test_process_changes_moved(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="moved" label="1234-1" parent="1234-Subpart-B"></change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <subpart label="1234-Subpart-A">
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </subpart>
+                <subpart label="1234-Subpart-B">
+                  <paragraph label="1234-2">Another existing paragraph</paragraph>
+                </subpart>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertEqual(moved_para.getparent().get('label'),
+                         '1234-Subpart-B')
+        self.assertEqual(moved_para.getparent().index(moved_para), 1)
+        old_parent = new_xml.find('.//{eregs}subpart[@label="1234-Subpart-A"]')
+        self.assertEqual(len(old_parent.getchildren()), 0)
+
+    def test_process_changes_moved_before(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="moved" label="1234-1" parent="1234-Subpart-B" before="1234-2"></change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <subpart label="1234-Subpart-A">
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </subpart>
+                <subpart label="1234-Subpart-B">
+                  <paragraph label="1234-2">Another existing paragraph</paragraph>
+                </subpart>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertEqual(moved_para.getparent().get('label'),
+                         '1234-Subpart-B')
+        self.assertEqual(moved_para.getparent().index(moved_para), 0)
+
+    def test_process_changes_moved_after(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="moved" label="1234-1" parent="1234-Subpart-B" after="1234-2"></change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <subpart label="1234-Subpart-A">
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </subpart>
+                <subpart label="1234-Subpart-B">
+                  <paragraph label="1234-2">Another existing paragraph</paragraph>
+                  <paragraph label="1234-3">One more existing paragraph</paragraph>
+                </subpart>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
+        self.assertEqual(moved_para.getparent().get('label'),
+                         '1234-Subpart-B')
+        self.assertEqual(moved_para.getparent().index(moved_para), 1)
+
     def test_generate_diff_added(self):
         left_xml = etree.fromstring("""
             <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">


### PR DESCRIPTION
This PR adds support for the “moved” operation to the change processing.

See the tests for an example case.

**Note: We really need to refactor `process_changes()`. It’s getting unwieldy.**
