### PR TITLE
Bug fixes for added/moved changes

### DIFF
--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -207,6 +207,11 @@ def process_changes(original_xml, notice_xml, dry=False):
             if parent_label is None:
                 parent_label = '-'.join(get_parent_label(label_parts))
             parent_elm = new_xml.find('.//*[@label="{}"]'.format(parent_label))
+
+            # If the parent is a part or subpart, we need to add to the
+            # content element.
+            if parent_elm.tag in ("{eregs}part", "{eregs}subpart"):
+                parent_elm = parent_elm.find('./{eregs}content')
  
             # Figure out where we're putting the new element 
             # If we're given a before or after label, look
@@ -236,14 +241,17 @@ def process_changes(original_xml, notice_xml, dry=False):
                     sibling_label = '-'.join(sibling_label_parts)
                     sibling_elm = new_xml.find(
                         './/*[@label="{}"]'.format(sibling_label))
-                
-                    new_index = parent_elm.index(sibling_elm) + 1
+
+                    try:
+                        new_index = parent_elm.index(sibling_elm) + 1
+                    except ValueError:
+                        new_index = len(parent_elm.getchildren())
                 # Give up on a particular location and append to the end
                 # of the parent.
                 else:
                     new_index = len(parent_elm.getchildren())
 
-             if sibling_label is not None:
+            if sibling_label is not None:
                 # Perform TOC updates if needed
                 # - Determine whether the sibling's label appears in TOC(s)
                 # - If so, after the sibling's tocSecEntry, create a tocSecEntry for the new addition
@@ -283,8 +291,8 @@ def process_changes(original_xml, notice_xml, dry=False):
             # Find a match to the given label
             matching_elm = new_xml.find('.//*[@label="{}"]'.format(label))
             if matching_elm is None:
-                raise KeyError("Unable to find label {} {} in "
-                               "notice.".format(label, op))
+                raise KeyError("Unable to find label {} to be "
+                               "{}".format(label, op))
 
             match_parent = matching_elm.getparent()
 
@@ -301,6 +309,11 @@ def process_changes(original_xml, notice_xml, dry=False):
                     raise ValueError("'parent' attribute is required "
                                      "for 'moved' operation on "
                                      "{}".format(label))
+
+                # If the parent is a part or subpart, we need to add to the
+                # content element.
+                if parent_elm.tag in ("{eregs}part", "{eregs}subpart"):
+                    parent_elm = parent_elm.find('./{eregs}content')
 
                 # Figure out where we're putting the element when we
                 # move it. If we're given a before or after label, look

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -166,6 +166,7 @@ def process_changes(original_xml, notice_xml, dry=False):
         if op == 'added':
             before_label = change.get('before')
             after_label = change.get('after')
+            parent_label = change.get('parent')
         
             label_parts = label.split('-')
             new_elm = change.getchildren()[0]
@@ -179,9 +180,10 @@ def process_changes(original_xml, notice_xml, dry=False):
                                "change?".format(label))
 
             # Get the parent of the added label
-            parent_label = '-'.join(get_parent_label(label_parts))
+            if parent_label is None:
+                parent_label = '-'.join(get_parent_label(label_parts))
             parent_elm = new_xml.find('.//*[@label="{}"]'.format(parent_label))
-
+ 
             # Figure out where we're putting the new element 
             # If we're given a before or after label, look
             # for the corresponding elements.
@@ -199,6 +201,10 @@ def process_changes(original_xml, notice_xml, dry=False):
                 sibling_elm = new_xml.find('.//*[@label="{}"]'.format(
                     after_label))
                 new_index = parent_elm.index(sibling_elm) + 1
+            # If there's an explicit parent but no siblings, insert at
+            # the beginning of the parent.
+            elif change.get('parent') is not None:
+                new_index = 0
             else:
                 # Guess the preceding sibling
                 sibling_label_parts = get_sibling_label(label_parts)

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -101,7 +101,9 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-1">An existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -125,6 +127,7 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
+                <content/>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -147,8 +150,10 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-1">An existing paragraph</paragraph>
-                <paragraph label="1234-2">Another existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                  <paragraph label="1234-2">Another existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         with self.assertRaises(KeyError):
@@ -171,8 +176,10 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <subpart></subpart>
-                <appendix label="1234-A"></appendix>
+                <content>
+                  <subpart><content/></subpart>
+                  <appendix label="1234-A"></appendix>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -195,7 +202,9 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-2">An existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-2">An existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -217,8 +226,10 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-1">An existing paragraph</paragraph>
-                <paragraph label="1234-3">Another existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                  <paragraph label="1234-3">Another existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -240,7 +251,9 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-1">An existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -262,7 +275,9 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <paragraph label="1234-1">An existing paragraph</paragraph>
+                <content>
+                  <paragraph label="1234-1">An existing paragraph</paragraph>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
@@ -282,20 +297,26 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <subpart label="1234-Subpart-A">
-                  <paragraph label="1234-1">An existing paragraph</paragraph>
-                </subpart>
-                <subpart label="1234-Subpart-B">
-                  <paragraph label="1234-2">Another existing paragraph</paragraph>
-                </subpart>
+                <content>
+                  <subpart label="1234-Subpart-A">
+                    <content>
+                      <paragraph label="1234-1">An existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                  <subpart label="1234-Subpart-B">
+                    <content>
+                      <paragraph label="1234-2">Another existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
         moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
-        self.assertEqual(moved_para.getparent().get('label'),
+        self.assertEqual(moved_para.getparent().getparent().get('label'),
                          '1234-Subpart-B')
         self.assertEqual(moved_para.getparent().index(moved_para), 1)
-        old_parent = new_xml.find('.//{eregs}subpart[@label="1234-Subpart-A"]')
+        old_parent = new_xml.find('.//{eregs}subpart[@label="1234-Subpart-A"]/{eregs}content')
         self.assertEqual(len(old_parent.getchildren()), 0)
 
     def test_process_changes_moved_before(self):
@@ -311,17 +332,23 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <subpart label="1234-Subpart-A">
-                  <paragraph label="1234-1">An existing paragraph</paragraph>
-                </subpart>
-                <subpart label="1234-Subpart-B">
-                  <paragraph label="1234-2">Another existing paragraph</paragraph>
-                </subpart>
+                <content>
+                  <subpart label="1234-Subpart-A">
+                    <content>
+                      <paragraph label="1234-1">An existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                  <subpart label="1234-Subpart-B">
+                    <content>
+                      <paragraph label="1234-2">Another existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
         moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
-        self.assertEqual(moved_para.getparent().get('label'),
+        self.assertEqual(moved_para.getparent().getparent().get('label'),
                          '1234-Subpart-B')
         self.assertEqual(moved_para.getparent().index(moved_para), 0)
 
@@ -338,18 +365,24 @@ class ChangesTests(TestCase):
               <fdsys></fdsys>
               <preamble></preamble>
               <part label="1234">
-                <subpart label="1234-Subpart-A">
-                  <paragraph label="1234-1">An existing paragraph</paragraph>
-                </subpart>
-                <subpart label="1234-Subpart-B">
-                  <paragraph label="1234-2">Another existing paragraph</paragraph>
-                  <paragraph label="1234-3">One more existing paragraph</paragraph>
-                </subpart>
+                <content>
+                  <subpart label="1234-Subpart-A">
+                    <content>
+                      <paragraph label="1234-1">An existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                  <subpart label="1234-Subpart-B">
+                    <content>
+                      <paragraph label="1234-2">Another existing paragraph</paragraph>
+                      <paragraph label="1234-3">One more existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                </content>
               </part>
             </regulation>""")
         new_xml = process_changes(original_xml, notice_xml)
         moved_para = new_xml.find('.//{eregs}paragraph[@label="1234-1"]')
-        self.assertEqual(moved_para.getparent().get('label'),
+        self.assertEqual(moved_para.getparent().getparent().get('label'),
                          '1234-Subpart-B')
         self.assertEqual(moved_para.getparent().index(moved_para), 1)
 
@@ -558,9 +591,11 @@ class ChangesTests(TestCase):
                     <appendixSubject>Appendix A - [Reserved]</appendixSubject>
                   </tocAppEntry>
                 </tableOfContents>
-                <subpart></subpart>
-                <section label="1234-1"></section>
-                <appendix label="1234-A"></appendix>
+                <content>
+                  <subpart></subpart>
+                  <section label="1234-1"></section>
+                  <appendix label="1234-A"></appendix>
+                </content>
               </part>
             </regulation>""")
         # Code for testing - on addition update, the TOC should get filled out with additional information


### PR DESCRIPTION
This PR fixes a few minor bugs with added/moved changes:
- `part` and `subpart` parents have `content` elements that need to contain their children.
- use `parent` for added changes
- Insert added elements at the beginning of a parent that has no children
