### PR TITLE
TOC Manually

### DIFF
--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -251,35 +251,35 @@ def process_changes(original_xml, notice_xml, dry=False):
                 else:
                     new_index = len(parent_elm.getchildren())
 
-            if sibling_label is not None:
-                # Perform TOC updates if needed
-                # - Determine whether the sibling's label appears in TOC(s)
-                # - If so, after the sibling's tocSecEntry, create a tocSecEntry for the new addition
-                # - Insert the new tocSecEntry after the sibling's tocSecEntry
-                for toc in tocs:
-                    sib_in_toc = find_toc_entry(toc, sibling_label)
-
-                    # If sibling is not in the TOC, don't add this label
-                    if sib_in_toc is None:
-                        continue
-
-                    # Determine element type
-                    item = change[0]
-                    item_toc = get_toc_type(item.tag)
-
-                    # If element type is a TOC type, add it after its sibling
-                    if item_toc is not None:
-                        des_tag, subj_tag = get_toc_change_keywords(item_toc)
-
-                        if len(des_tag) > 0:
-                            toc_des = item.get(des_tag)
-                        else:
-                            toc_des = ""
-                        toc_subject = item.find(subj_tag).text
-
-                        if not dry:
-                            create_toc_entry(toc, label, toc_des, toc_subject, 
-                                             after_elm=sib_in_toc, entry_type=item_toc)
+#            if sibling_label is not None:
+#                # Perform TOC updates if needed
+#                # - Determine whether the sibling's label appears in TOC(s)
+#                # - If so, after the sibling's tocSecEntry, create a tocSecEntry for the new addition
+#                # - Insert the new tocSecEntry after the sibling's tocSecEntry
+#                for toc in tocs:
+#                    sib_in_toc = find_toc_entry(toc, sibling_label)
+#
+#                    # If sibling is not in the TOC, don't add this label
+#                    if sib_in_toc is None:
+#                        continue
+#
+#                    # Determine element type
+#                    item = change[0]
+#                    item_toc = get_toc_type(item.tag)
+#
+#                    # If element type is a TOC type, add it after its sibling
+#                    if item_toc is not None:
+#                        des_tag, subj_tag = get_toc_change_keywords(item_toc)
+#
+#                        if len(des_tag) > 0:
+#                            toc_des = item.get(des_tag)
+#                        else:
+#                            toc_des = ""
+#                        toc_subject = item.find(subj_tag).text
+#
+#                        if not dry:
+#                            create_toc_entry(toc, label, toc_des, toc_subject, 
+#                                             after_elm=sib_in_toc, entry_type=item_toc)
 
             # Insert the new xml!
             if not dry:
@@ -341,44 +341,44 @@ def process_changes(original_xml, notice_xml, dry=False):
                     raise ValueError("Tried to modify {}, but no "
                                      "replacement given".format(label))
 
-                # Look for whether a modified label exists in a TOC and if so, update TOCs
-                # If the label exists as a TOC entry target, update the number/letter and subject
-                item = change[0]
-                toc_tag = get_toc_type(item.tag)
-
-                if toc_tag is not None:
-                    logging.debug("Found {}-type modification".format(toc_tag))
-                    # Double-check labels match
-                    toc_label = item.get('label')
-                    if toc_label != label:
-                        logging.warning("Label mismatch: change label '{}' does not match item label '{}'".format(label, toc_label))
-                    else:
-                        toc_updates = multi_find_toc_entry(tocs, label)
-
-                        # If label doesn't appear in any TOCs, move on
-                        if len(toc_updates) != 0:
-                            des_tag, subj_tag = get_toc_change_keywords(toc_tag)
-
-                            if len(des_tag) > 0:
-                                toc_des = item.get(des_tag)
-                            else:
-                                toc_des = ""
-                            toc_subject = item.find(subj_tag).text
-
-                            logging.debug("Found {} TOC entries for item {} ('{}'): '{}'".format(len(toc_updates),
-                                                                                                 toc_des,
-                                                                                                 label,
-                                                                                                 toc_subject))
-                            # Make applicable TOC changes
-                            if not dry:
-                                changed = 0
-                                for toc_entry in toc_updates:
-                                    changed += update_toc_entry(toc_entry, toc_des, toc_subject, entry_type=toc_tag)
-                                logging.info("Made {} updates to TOC entries for item {} ('{}')".format(changed,
-                                                                                                        toc_des,
-                                                                                                        label))
-                else:
-                    logging.debug("Modification of tag '{}' not a TOC-type".format(toc_tag))
+#                # Look for whether a modified label exists in a TOC and if so, update TOCs
+#                # If the label exists as a TOC entry target, update the number/letter and subject
+#                item = change[0]
+#                toc_tag = get_toc_type(item.tag)
+#
+#                if toc_tag is not None:
+#                    logging.debug("Found {}-type modification".format(toc_tag))
+#                    # Double-check labels match
+#                    toc_label = item.get('label')
+#                    if toc_label != label:
+#                        logging.warning("Label mismatch: change label '{}' does not match item label '{}'".format(label, toc_label))
+#                    else:
+#                        toc_updates = multi_find_toc_entry(tocs, label)
+#
+#                        # If label doesn't appear in any TOCs, move on
+#                        if len(toc_updates) != 0:
+#                            des_tag, subj_tag = get_toc_change_keywords(toc_tag)
+#
+#                            if len(des_tag) > 0:
+#                                toc_des = item.get(des_tag)
+#                            else:
+#                                toc_des = ""
+#                            toc_subject = item.find(subj_tag).text
+#
+#                            logging.debug("Found {} TOC entries for item {} ('{}'): '{}'".format(len(toc_updates),
+#                                                                                                 toc_des,
+#                                                                                                 label,
+#                                                                                                 toc_subject))
+#                            # Make applicable TOC changes
+#                            if not dry:
+#                                changed = 0
+#                                for toc_entry in toc_updates:
+#                                    changed += update_toc_entry(toc_entry, toc_des, toc_subject, entry_type=toc_tag)
+#                                logging.info("Made {} updates to TOC entries for item {} ('{}')".format(changed,
+#                                                                                                        toc_des,
+#                                                                                                        label))
+#                else:
+#                    logging.debug("Modification of tag '{}' not a TOC-type".format(toc_tag))
 
                 if not dry:
                     new_elm = change.getchildren()[0]
@@ -391,15 +391,15 @@ def process_changes(original_xml, notice_xml, dry=False):
                 toc_updates = multi_find_toc_entry(tocs, label)
 
                 if not dry:
-                    # Remove the TOC entries that target this label
-                    changed = 0
-                    for toc_entry in toc_updates:
-                        delete_toc_entry(toc_entry)
-                        changed += 1
-                    
-                    # Report how many deletions occurred
-                    if changed > 0:
-                        logging.info("Made {} deletions of TOC entries for item '{}'".format(changed, label))
+#                    # Remove the TOC entries that target this label
+#                    changed = 0
+#                    for toc_entry in toc_updates:
+#                        delete_toc_entry(toc_entry)
+#                        changed += 1
+#                    
+#                    # Report how many deletions occurred
+#                    if changed > 0:
+#                        logging.info("Made {} deletions of TOC entries for item '{}'".format(changed, label))
 
                     # Remove the element itself
                     match_parent.remove(matching_elm)

--- a/settings.py
+++ b/settings.py
@@ -2,7 +2,7 @@ import os
 
 XML_ROOT = '../regulations-xml'
 JSON_ROOT = '../regulations-stub/stub'
-XSD_FILE = 'http://cfpb.github.io/regulations-schema/src/eregs.xsd'
+XSD_FILE = '../regulations-schema/src/eregs.xsd'
 
 # the inflect module has a few problems... manual override for that
 SPECIAL_SINGULAR_NOUNS = [

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -553,141 +553,141 @@ class ChangesTests(TestCase):
         self.assertEqual(diff['1234-1-a']['op'], 'deleted')
 
 
-    def test_process_changes_toc_added(self):
-        # Note: Does not currently test Subpart adding
-        notice_xml = etree.fromstring("""
-            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys><preamble></preamble>
-              <changeset>
-                <change operation="added" label="1234-2">
-                  <section label="1234-2" sectionNum="2">
-                    <subject>1234.2 New Title</subject>
-                  </section>
-                </change>
-                <change operation="added" label="1234-Interp">
-                  <interpretations label="1234-Interp">
-                    <interpTitle>Supplement I to Part 1234</interpTitle>
-                  </interpretations>
-                </change>
-                <change operation="added" label="1234-B">
-                  <appendix appendixLetter="B" label="1024-B">
-                    <appendixTitle>Appendix B to Part 1234—Title parts</appendixTitle>
-                  </appendix>
-                </change>                
-             </changeset>
-            </notice>""")
-        original_xml = etree.fromstring("""
-            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys>
-              <preamble></preamble>
-              <part label="1234">
-                <tableOfContents>
-                  <tocSecEntry target="1234-1">
-                    <sectionNum>1</sectionNum>
-                    <sectionSubject>§ 1234.1 Designation.</sectionSubject>
-                  </tocSecEntry>
-                <tocAppEntry target="1234-A">
-                    <appendixLetter>A</appendixLetter>
-                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
-                  </tocAppEntry>
-                </tableOfContents>
-                <content>
-                  <subpart></subpart>
-                  <section label="1234-1"></section>
-                  <appendix label="1234-A"></appendix>
-                </content>
-              </part>
-            </regulation>""")
-        # Code for testing - on addition update, the TOC should get filled out with additional information
-        # and have 4 elements instead of 2 - the added Interp has no sibling so does not get added to the TOC
-        new_xml = process_changes(original_xml, notice_xml)
-        toc_root = new_xml.find('.//{eregs}tableOfContents')
-        num_children = len([el for el in toc_root.iterchildren()])
-        self.assertEqual(num_children, 4)
-
-
-    def test_process_changes_toc_modified(self):
-        # Note: Does not currently test Subpart modification
-        notice_xml = etree.fromstring("""
-            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys><preamble></preamble>
-              <changeset>
-                <change operation="modified" label="1234-1">
-                  <section label="1234-1" sectionNum="1">
-                    <subject>1234.1 New Title</subject>
-                  </section>
-                </change>
-                <change operation="modified" label="1234-Interp">
-                  <interpretations label="1234-Interp">
-                    <title>Supplement I to Part 1234</title>
-                  </interpretations>
-                </change>
-                <change operation="modified" label="1234-A">
-                  <appendix appendixLetter="A" label="1234-A">
-                    <appendixTitle>Appendix A to Part 1234—Title parts that are new</appendixTitle>
-                  </appendix>
-                </change>                
-             </changeset>
-            </notice>""")
-        original_xml = etree.fromstring("""
-            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys>
-              <preamble></preamble>
-              <part label="1234">
-                <tableOfContents>
-                  <tocSecEntry target="1234-1">
-                  </tocSecEntry>
-                  <tocInterpEntry target="1234-Interp">
-                  </tocInterpEntry>
-                  <tocAppEntry target="1234-A">
-                    <appendixLetter>A</appendixLetter>
-                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
-                  </tocAppEntry>
-                </tableOfContents>
-                <subpart></subpart>
-                <section label="1234-1"></section>
-                <interpretations label="1234-Interp"></interpretations>
-                <appendix label="1234-A"></appendix>
-              </part>
-            </regulation>""")
-        # Code for testing - on modification update, the TOC should get filled out with additional information
-        # and have 5 leaf-elements instead of 2
-        new_xml = process_changes(original_xml, notice_xml)
-        toc_root = new_xml.find('.//{eregs}tableOfContents')
-        num_children = sum([len(el) for el in toc_root.iterchildren()])
-        self.assertEqual(num_children, 5)
-
-
-    def test_process_changes_toc_deletion(self):
-        notice_xml = etree.fromstring("""
-            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys><preamble></preamble>
-              <changeset>
-                <change operation="deleted" label="1234-1"></change>
-              </changeset>
-            </notice>""")
-        original_xml = etree.fromstring("""
-            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
-              <fdsys></fdsys>
-              <preamble></preamble>
-              <part label="1234">
-                <tableOfContents>
-                  <tocSecEntry target="1234-1">
-                    <sectionNum>1</sectionNum>
-                    <sectionSubject>§ 1234.1 Designation.</sectionSubject>
-                  </tocSecEntry>
-                <tocAppEntry target="1234-A">
-                    <appendixLetter>A</appendixLetter>
-                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
-                  </tocAppEntry>
-                </tableOfContents>
-                <subpart></subpart>
-                <section label="1234-1"></section>
-                <appendix label="1234-A"></appendix>
-              </part>
-            </regulation>""")
-        new_xml = process_changes(original_xml, notice_xml)
-        del_sec = new_xml.findall('.//{eregs}section[@label="1234-1"]')
-        del_app = new_xml.findall('.//{eregs}appendix[@label="1234-A"]')
-        self.assertEqual(len(del_sec), 0)
-        self.assertEqual(len(del_app), 1)
+#    def test_process_changes_toc_added(self):
+#        # Note: Does not currently test Subpart adding
+#        notice_xml = etree.fromstring("""
+#            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys><preamble></preamble>
+#              <changeset>
+#                <change operation="added" label="1234-2">
+#                  <section label="1234-2" sectionNum="2">
+#                    <subject>1234.2 New Title</subject>
+#                  </section>
+#                </change>
+#                <change operation="added" label="1234-Interp">
+#                  <interpretations label="1234-Interp">
+#                    <interpTitle>Supplement I to Part 1234</interpTitle>
+#                  </interpretations>
+#                </change>
+#                <change operation="added" label="1234-B">
+#                  <appendix appendixLetter="B" label="1024-B">
+#                    <appendixTitle>Appendix B to Part 1234—Title parts</appendixTitle>
+#                  </appendix>
+#                </change>                
+#             </changeset>
+#            </notice>""")
+#        original_xml = etree.fromstring("""
+#            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys>
+#              <preamble></preamble>
+#              <part label="1234">
+#                <tableOfContents>
+#                  <tocSecEntry target="1234-1">
+#                    <sectionNum>1</sectionNum>
+#                    <sectionSubject>§ 1234.1 Designation.</sectionSubject>
+#                  </tocSecEntry>
+#                <tocAppEntry target="1234-A">
+#                    <appendixLetter>A</appendixLetter>
+#                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
+#                  </tocAppEntry>
+#                </tableOfContents>
+#                <content>
+#                  <subpart></subpart>
+#                  <section label="1234-1"></section>
+#                  <appendix label="1234-A"></appendix>
+#                </content>
+#              </part>
+#            </regulation>""")
+#        # Code for testing - on addition update, the TOC should get filled out with additional information
+#        # and have 4 elements instead of 2 - the added Interp has no sibling so does not get added to the TOC
+#        new_xml = process_changes(original_xml, notice_xml)
+#        toc_root = new_xml.find('.//{eregs}tableOfContents')
+#        num_children = len([el for el in toc_root.iterchildren()])
+#        self.assertEqual(num_children, 4)
+#
+#
+#    def test_process_changes_toc_modified(self):
+#        # Note: Does not currently test Subpart modification
+#        notice_xml = etree.fromstring("""
+#            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys><preamble></preamble>
+#              <changeset>
+#                <change operation="modified" label="1234-1">
+#                  <section label="1234-1" sectionNum="1">
+#                    <subject>1234.1 New Title</subject>
+#                  </section>
+#                </change>
+#                <change operation="modified" label="1234-Interp">
+#                  <interpretations label="1234-Interp">
+#                    <title>Supplement I to Part 1234</title>
+#                  </interpretations>
+#                </change>
+#                <change operation="modified" label="1234-A">
+#                  <appendix appendixLetter="A" label="1234-A">
+#                    <appendixTitle>Appendix A to Part 1234—Title parts that are new</appendixTitle>
+#                  </appendix>
+#                </change>                
+#             </changeset>
+#            </notice>""")
+#        original_xml = etree.fromstring("""
+#            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys>
+#              <preamble></preamble>
+#              <part label="1234">
+#                <tableOfContents>
+#                  <tocSecEntry target="1234-1">
+#                  </tocSecEntry>
+#                  <tocInterpEntry target="1234-Interp">
+#                  </tocInterpEntry>
+#                  <tocAppEntry target="1234-A">
+#                    <appendixLetter>A</appendixLetter>
+#                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
+#                  </tocAppEntry>
+#                </tableOfContents>
+#                <subpart></subpart>
+#                <section label="1234-1"></section>
+#                <interpretations label="1234-Interp"></interpretations>
+#                <appendix label="1234-A"></appendix>
+#              </part>
+#            </regulation>""")
+#        # Code for testing - on modification update, the TOC should get filled out with additional information
+#        # and have 5 leaf-elements instead of 2
+#        new_xml = process_changes(original_xml, notice_xml)
+#        toc_root = new_xml.find('.//{eregs}tableOfContents')
+#        num_children = sum([len(el) for el in toc_root.iterchildren()])
+#        self.assertEqual(num_children, 5)
+#
+#
+#    def test_process_changes_toc_deletion(self):
+#        notice_xml = etree.fromstring("""
+#            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys><preamble></preamble>
+#              <changeset>
+#                <change operation="deleted" label="1234-1"></change>
+#              </changeset>
+#            </notice>""")
+#        original_xml = etree.fromstring("""
+#            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+#              <fdsys></fdsys>
+#              <preamble></preamble>
+#              <part label="1234">
+#                <tableOfContents>
+#                  <tocSecEntry target="1234-1">
+#                    <sectionNum>1</sectionNum>
+#                    <sectionSubject>§ 1234.1 Designation.</sectionSubject>
+#                  </tocSecEntry>
+#                <tocAppEntry target="1234-A">
+#                    <appendixLetter>A</appendixLetter>
+#                    <appendixSubject>Appendix A - [Reserved]</appendixSubject>
+#                  </tocAppEntry>
+#                </tableOfContents>
+#                <subpart></subpart>
+#                <section label="1234-1"></section>
+#                <appendix label="1234-A"></appendix>
+#              </part>
+#            </regulation>""")
+#        new_xml = process_changes(original_xml, notice_xml)
+#        del_sec = new_xml.findall('.//{eregs}section[@label="1234-1"]')
+#        del_app = new_xml.findall('.//{eregs}appendix[@label="1234-A"]')
+#        self.assertEqual(len(del_sec), 0)
+#        self.assertEqual(len(del_app), 1)


### PR DESCRIPTION
This PR disables the programmatic TOC modification in favor of using `<change>`s and giving TOCs labels.

Corresponds to https://github.com/cfpb/regulations-schema/pull/6
