### PR TITLE
Fix dashes

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -451,9 +451,9 @@ def build_formatting_layer(root):
                 dash_text = dash.text
                 if dash_text is None:
                     dash_text = ''
-                dash_dict['text'] = dash_text
                 dash_dict['dash_data'] = {'text': dash_text}
                 dash_dict['locations'] = [0]
+                dash_dict['text'] = dash_text + '_____'
                 layer_dict[label].append(dash_dict)
 
         if len(variables) > 0:
@@ -601,6 +601,25 @@ def apply_formatting(content_elm):
             working_content.text = '```\n' + \
                         '\n'.join([l.text for l in lines]) + \
                         '```'
+
+    # Do the same for dashes.
+    dashes = working_content.findall('.//{eregs}dash')
+    for dash in dashes:
+        # Dashes have to end a line, so we ignore the dash's tail
+        dash_text = dash.text
+        if dash_text is None:
+            dash_text = ''
+
+        dash_text = dash_text + '_____'
+
+        # Append the dash_text to either parent or previous sibling to
+        # replace the dash element.
+        previous = dash.getprevious()
+        if previous is not None:
+            previous.tail = (previous.tail or '') + dash_text
+        else:
+            working_content.text = (working_content.text or '') + dash_text
+        working_content.remove(dash)
 
     return working_content
 

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -296,7 +296,7 @@ class TreeTestCase(TestCase):
 
     def test_apply_formatting_dash(self):
         content = etree.fromstring("""
-        <content>
+        <content xmlns="eregs">
           <dash>Date</dash>
         </content>
         """, parser=etree.XMLParser(remove_blank_text=True))

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -270,6 +270,44 @@ class TreeTestCase(TestCase):
         result = apply_formatting(content)
         self.assertEqual(expected_result.text.strip(), result.text)
 
+    def test_build_formatting_layer_dash(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs">
+          <paragraph label="foo">
+            <content>
+              <dash>Date</dash>
+            </content>
+          </paragraph>
+        </section>
+        """, parser=etree.XMLParser(remove_blank_text=True))
+        expected_result = {
+            'foo': [{
+                'dash_data': {
+                    'text': 'Date'
+                }, 
+                'locations': [
+                    0
+                ], 
+                'text': 'Date_____',
+            }]
+        }
+        result = build_formatting_layer(tree)
+        self.assertEqual(expected_result, result)
+
+    def test_apply_formatting_dash(self):
+        content = etree.fromstring("""
+        <content>
+          <dash>Date</dash>
+        </content>
+        """, parser=etree.XMLParser(remove_blank_text=True))
+        expected_result = etree.fromstring("""
+        <content xmlns="eregs">
+          Date_____
+        </content>
+        """, parser=etree.XMLParser(remove_blank_text=True))
+        result = apply_formatting(content)
+        self.assertEqual(expected_result.text.strip(), result.text)
+
     def test_build_reg_tree_intro_para(self):
         tree = etree.fromstring("""
         <section label="foo" xmlns="eregs">


### PR DESCRIPTION
This PR adds full support for dashes to the xml parser. 

The `dash` element is used in model forms to indicate input, i.e.

```
<paragraph>
  <content>
    <dash>Date</dash>
  </content>
</paragraph>
```

Will render in the JSON as:

```
Date_____
```

Which will in turn be displayed by the front-end as the text `Date` with a an underline following it until the end of the line.

Tests are included.
