### PR TITLE
Make TOC handling less dependent on structure, more testable

### DIFF
--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -14,7 +14,8 @@ from regulation.tree import (build_reg_tree,
                              build_analysis,
                              build_notice,
                              build_formatting_layer,
-                             apply_formatting)
+                             apply_formatting,
+                             build_toc_layer)
 from regulation.node import RegNode
 
 
@@ -522,4 +523,124 @@ class TreeTestCase(TestCase):
                                                      (u'reference', '1024-defs'),
                                                      (u'term', 'respa')]))]))])
 
+        self.assertEqual(expected_result, result)
+
+    def test_build_toc_layer_part(self):
+        tree = etree.fromstring("""
+        <part xmlns="eregs" label="1234">
+          <tableOfContents>
+            <tocSecEntry target="1234-1">
+              <sectionNum>1</sectionNum>
+              <sectionSubject>§ 1234.1</sectionSubject>
+            </tocSecEntry>
+            <tocAppEntry target="1234-A">
+              <appendixLetter>A</appendixLetter>
+              <appendixSubject>Appendix</appendixSubject>
+            </tocAppEntry>
+          </tableOfContents>
+          <content/>
+        </part>
+        """)
+        expected_result = {
+            '1234': [
+                {'index': [u'1234', u'1'], 'title': u'\xa7 1234.1'},
+                {'index': [u'1234', u'A'], 'title': 'Appendix'}
+            ],
+        }
+        result = build_toc_layer(tree)
+        self.assertEqual(expected_result, result)
+        
+    def test_build_toc_layer_subpart(self):
+        tree = etree.fromstring("""
+        <subpart xmlns="eregs" subpartLetter="A" label="1234-Subpart-A">
+          <title>General</title>
+          <tableOfContents label="1234-Subpart-A-TOC">
+            <tocSecEntry target="1234-1">
+              <sectionNum>1</sectionNum>
+              <sectionSubject>§ 1234.1</sectionSubject>
+            </tocSecEntry>
+            <tocSecEntry target="1234-1">
+              <sectionNum>1</sectionNum>
+              <sectionSubject>§ 1234.2</sectionSubject>
+            </tocSecEntry>
+          </tableOfContents>
+          <content></content>
+        </subpart>
+        """)
+        expected_result = {
+            '1234-Subpart-A': [
+                {'index': [u'1234', u'1'], 'title': u'\xa7 1234.1'},
+                {'index': [u'1234', u'1'], 'title': u'\xa7 1234.2'}
+            ],
+        }
+        result = build_toc_layer(tree)
+        self.assertEqual(expected_result, result)
+        
+    def test_build_toc_layer_section(self):
+        tree = etree.fromstring("""
+        <section xmlns="eregs" label="1234-1" sectionNum="1">
+          <subject>§ 1234.1</subject>
+          <tableOfContents label="1234-Subpart-A-TOC">
+            <tocSecEntry target="1234-1-a">
+              <sectionNum>1</sectionNum>
+              <sectionSubject>§ 1234.1(a)</sectionSubject>
+            </tocSecEntry>
+          </tableOfContents>
+          <paragraph label="1234-1-a" marker="a">
+            <content>This is a section with its own TOC</content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            '1234-1': [
+                {u'index': [u'1234', u'1', u'a'], u'title': u'\xa7 1234.1(a)'}
+            ],
+        }
+        result = build_toc_layer(tree)
+        self.assertEqual(expected_result, result)
+
+    def test_build_toc_layer_appendix(self):
+        tree = etree.fromstring("""
+        <appendix xmlns="eregs" appendixLetter="A" label="1234-A">
+          <appendixTitle>Appendix A</appendixTitle>
+          <tableOfContents>
+            <tocAppEntry target="1234-A-1">
+              <appendixLetter>A-1</appendixLetter>
+              <appendixSubject>Some Subject</appendixSubject>
+            </tocAppEntry>
+          </tableOfContents>
+        </appendix>
+        """)
+        expected_result = {
+            '1234-A': [
+                {u'index': [u'1234', u'A', u'1'], u'title': 'Some Subject'}
+            ],
+        }
+        result = build_toc_layer(tree)
+        self.assertEqual(expected_result, result)
+        
+    def test_build_toc_layer_appendix_section(self):
+        tree = etree.fromstring("""
+        <appendix xmlns="eregs" appendixLetter="A" label="1234-A">
+          <appendixTitle>Appendix A</appendixTitle>
+          <appendixSection appendixSecNum="1" label="1234-A-1">
+            <subject>Section 1</subject>
+            <tableOfContents>
+              <tocAppEntry target="1234-A-1-A">
+                <appendixLetter>A-1-A</appendixLetter>
+                <appendixSubject>Something</appendixSubject>
+              </tocAppEntry>
+            </tableOfContents>
+            <paragraph label="1234-A-1-A" marker="">
+              <content>Something here</content>
+            </paragraph>
+          </appendixSection>
+        </appendix>
+        """)
+        expected_result = {
+            '1234-A-1': [
+                {u'index': [u'1234', u'A', u'1', 'A'], u'title': 'Something'}
+            ],
+        }
+        result = build_toc_layer(tree)
         self.assertEqual(expected_result, result)


### PR DESCRIPTION
This PR refactors the `build_toc_layer` function, adding tests for the various places we might expect to find TOCs.
