### PR TITLE
Retain analysis text

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -1057,6 +1057,11 @@ def build_notice(root):
                     inline_img = '<img src="{}">'.format(url)
                     paragraph_text += '\n' + inline_img + '\n'
 
+                # If it's something else, like an em tag, include the
+                # text.
+                else:
+                    paragraph_text += p_child_elm.text or ''
+
                 # Append the footnote 'tail' to the paragraph text
                 tail = p_child_elm.tail or ''
                 paragraph_text += tail

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,6 +35,7 @@ test_xml = """
                         <analysisSection>
                           <title>(a) Section of the Analysis</title>
                           <analysisParagraph>I am a paragraph<footnote ref="1">Paragraphs contain text.</footnote> in an analysis<footnote ref="2">Analysis analyzes things.</footnote> section, love me!</analysisParagraph>
+                          <analysisParagraph>I am a paragraph with <em>italicized</em> text.</analysisParagraph>
                         </analysisSection>
                       </analysisSection>
                     </analysis>

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -105,6 +105,7 @@ class TreeTestCase(TestCase):
                     ],
                     'paragraphs': [
                         'I am a paragraph in an analysis section, love me!',
+                        'I am a paragraph with italicized text.',
                     ],
                     'title': '(a) Section of the Analysis'
                 }],


### PR DESCRIPTION
This PR fixes a bug where text in analysis that occurs within child elements (like `<em>`, which is fairly common) was being discarded.
