### PR TITLE
Add support for writing term-checker changes to notice files

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -476,6 +476,10 @@ def apply_notice(regulation_file, notice_file):
         notice_string = f.read()
     notice_xml = etree.fromstring(notice_string)
 
+    # Validate the files
+    regulation_validator = get_validator(left_xml_tree)
+    notice_validator = get_validator(notice_xml)
+
     # Process the notice changeset
     new_xml_tree = process_changes(left_xml_tree, notice_xml)
 
@@ -607,6 +611,10 @@ def apply_through(cfr_title, cfr_part, through=None):
         with open(notice_file, 'r') as f:
             notice_string = f.read()
         notice_xml = etree.fromstring(notice_string)
+
+        # Validate the files
+        regulation_validator = get_validator(prev_tree)
+        notice_validator = get_validator(notice_xml)
 
         # Process the notice changeset
         new_xml_tree = process_changes(prev_tree, notice_xml)

--- a/regml.py
+++ b/regml.py
@@ -228,25 +228,43 @@ def validate(file, no_terms=False, no_citations=False, no_keyterms=False):
 @click.argument('file')
 @click.option('--label')
 @click.option('--term')
-def check_terms(file, label=None, term=None):
+@click.option('--with-notice')
+def check_terms(file, label=None, term=None, with_notice=None):
     """ Check the terms in a RegML file """
 
     file = find_file(file)
     with open(file, 'r') as f:
-        reg_xml = f.read()
-    xml_tree = etree.fromstring(reg_xml)
+        reg_string = f.read()
+    reg_tree = etree.fromstring(reg_string)
 
-    if xml_tree.tag == '{eregs}notice':
-        print("Cannot check terms in notice files")
+    if reg_tree.tag == '{eregs}notice':
+        print("Cannot check terms in notice files directly.")
+        print("Use a regulation file and --with-notice to specify the notice that applies.")
         sys.exit(1)
 
-    # Validate the file relative to schema
-    validator = get_validator(xml_tree)
+    # If we're given a notice, apply it to the given regulation file,
+    # then check terms in the result and write it out to the notice file
+    # as changes.
+    notice_tree = None
+    if with_notice is not None:
+        # file is changed here so the term checker will write the notice
+        # instead of the regulation
+        file = find_file(with_notice, is_notice=True)
+        with open(file, 'r') as f:
+            notice_xml = f.read()
+        notice_tree = etree.fromstring(notice_xml)
 
-    terms = build_terms_layer(xml_tree)
-    validator.validate_terms(xml_tree, terms)
-    validator.validate_term_references(xml_tree, terms, file,
-            label=label, term=term)
+        # Process the notice changeset
+        print(colored('Applying notice...', attrs=['bold']))
+        reg_tree = process_changes(reg_tree, notice_tree)
+
+    # Validate the file relative to schema
+    validator = get_validator(reg_tree)
+
+    terms = build_terms_layer(reg_tree)
+    validator.validate_terms(reg_tree, terms)
+    validator.validate_term_references(reg_tree, terms, file,
+            label=label, term=term, notice=notice_tree)
 
 
 @cli.command()
@@ -410,7 +428,9 @@ def json_through(cfr_title, cfr_part, through=None, suppress_output=False):
         answer = None
         while answer not in [""] + possible_indices + possible_regs: 
             answer = raw_input('Press enter to apply all or enter document number: [all] ')
-        # print("Answer: '{}'".format(answer))
+        print("Answer: '{}'".format(answer))
+
+    print(possible_indices)
 
     if len(answer) == 0:
         # Apply JSON to all documents

--- a/regml.py
+++ b/regml.py
@@ -312,6 +312,15 @@ def check_changes(file, label=None):
 @click.argument('cfr_part')
 def migrate_analysis(cfr_title, cfr_part):
     """ Migrate analysis from its context to top-level """
+
+    # Prompt user to be sure they want to do this
+    print(colored('This will irrevocably modify all regulation and notice files for this regulation. '
+                  'Is this ok?', 'red'))
+    answer = None
+    while answer not in ['y', 'n']:
+        answer = raw_input('Migrate all analysis? y/n: ')
+    if answer != 'y':
+        return 
     
     # Migrate regulation files
     regml_reg_dir = os.path.join(settings.XML_ROOT, 'regulation', cfr_part, '*.xml')

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -319,6 +319,7 @@ def process_changes(original_xml, original_notice_xml, dry=False):
 
             old_target = change.get('oldTarget')
             new_target = change.get('newTarget')
+            target_text = change.text
 
             if old_target is None or new_target is None:
                 raise ValueError('Need to know both the old target and '
@@ -326,7 +327,8 @@ def process_changes(original_xml, original_notice_xml, dry=False):
 
             references = new_xml.findall('.//{{eregs}}ref[@target="{}"]'.format(old_target))
             for ref in references:
-                ref.set('target', new_target)
+                if target_text is None or ref.text.lower() == target_text.lower():
+                    ref.set('target', new_target)
 
     return new_xml
 

--- a/regulation/changes.py
+++ b/regulation/changes.py
@@ -117,14 +117,15 @@ def label_compare(left, right):
     return cmp(left, right)
 
 
-def process_changes(original_xml, notice_xml, dry=False):
+def process_changes(original_xml, original_notice_xml, dry=False):
     """ Process changes given in the notice_xml to modify the
         original_xml. The 'dry' param controls whether this is a
         dry run (True) or to apply the xml changes (False).
         The result is returned as a new XML tree. """
 
-    # Copy the original XML for our new tree
+    # Copy the original XML trees for our new tree
     new_xml = deepcopy(original_xml)
+    notice_xml = deepcopy(original_notice_xml)
 
     # Replace the fdsys and preamble with the notice preamble.
     fdsys_elm = new_xml.find('./{eregs}fdsys')

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -329,18 +329,10 @@ def find_all_occurrences(source, target):
     :rtype: :class:`list` of :class:`int`
     """
     positions = []
-    remainder = source
-    start = 0
-    while remainder != []:
-        pos = remainder.find(target)
-        if pos != -1:
-            positions.append(pos + start)
-            pivot = pos + len(target)
-            start += len(remainder[:pivot])
-            remainder = remainder[pivot:]
-        else:
-            remainder = []
-
+    results = re.finditer(r"\b" + re.escape(target.lower()) + r"\b",
+            source.lower())
+    for match in results:
+        positions.append(match.start())
     return positions
 
 

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -329,8 +329,7 @@ def find_all_occurrences(source, target):
     :rtype: :class:`list` of :class:`int`
     """
     positions = []
-    results = re.finditer(r"\b" + re.escape(target.lower()) + r"\b",
-            source.lower())
+    results = re.finditer(r"\b" + re.escape(target) + r"\b", source)
     for match in results:
         positions.append(match.start())
     return positions

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -280,6 +280,10 @@ class EregsValidator:
         :type terms_layer: :class:`collections.OrderedDict`
         :param regulation_file: path to the regulation file to which to save changes.
         :type regulation_file: :class:`str`
+        :param label: check the contents of this label within the regulation tree (entire reg tree if None)
+        :type label: :class:`str`
+        :param term: the term the check (all if None)
+        :type term: :class:`str`
         :return: None
         """
 
@@ -310,7 +314,10 @@ class EregsValidator:
                     './/*[@label="{}"]'.format(label))
 
         paragraphs = working_section.findall('.//{eregs}paragraph') + \
-                working_section.findall('.//{eregs}interpParagraph')
+                     working_section.findall('.//{eregs}interpParagraph')
+        if len(paragraphs) == 0 and 'aragraph' in working_section.tag:
+            paragraphs = [working_section,]
+
         ignore = set()
         always = set()
 

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -329,7 +329,7 @@ class EregsValidator:
             offsets_and_values = []
 
             for term in terms:
-                if term[0] not in ignore:
+                if term[0] not in ignore and label != term[1]:
                     input_state = None
                     term_locations = set(find_all_occurrences(par_text, term[0]))
                     plural_term = inf.plural(term[0])

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -822,16 +822,6 @@ class EregsValidator:
                 analyses[0].getparent().tag in ('{eregs}notice', '{eregs}regulation'):
             return tree
 
-        # Prompt user to be sure they want to do this
-        if regulation_file is not None:
-            print(colored('The file ' + regulation_file + ' has invalid old-style analysis. '
-                          'Should it be migrated?', 'red'))
-            answer = None
-            while answer not in ['y', 'n']:
-                answer = raw_input('Migrate and save? y/n: ')
-            if answer == 'n':
-                return tree
-
         # Create the top level analysis element
         analysis = etree.SubElement(tree, '{eregs}analysis')
 

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -267,7 +267,8 @@ class EregsValidator:
         self.events.append(event)
 
     def validate_term_references(self, tree, terms_layer,
-            regulation_file, label=None, term=None, notice=None):
+            regulation_file, label=None, term=None, notice=None,
+            ignore_phrases=[]):
         """
         Validate term references. If label is given, only validate
         term references within that label. If term is given, only
@@ -390,7 +391,7 @@ class EregsValidator:
                     notice_paragraph = notice.find('.//{tag}[@label="{label}"]'.format(
                         tag=paragraph.tag, label=label))
 
-                    if notice_paragraphs is None:
+                    if notice_paragraph is None:
                         print(colored('adding change for paragraph in notice\n', attrs=['bold']))
                         changeset = notice.find('.//{eregs}changeset')
                         change = etree.SubElement(changeset, 'change')

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -387,21 +387,20 @@ class EregsValidator:
                     # Otherwise, look for this paragraph in the notice.
                     # If it doesn't exist there, add a modified change
                     # for it.
-                    notice_paragraphs = notice.findall('.//{tag}[@label="{label}"]'.format(
+                    notice_paragraph = notice.find('.//{tag}[@label="{label}"]'.format(
                         tag=paragraph.tag, label=label))
 
-                    if len(notice_paragraphs) == 0:
-                        print(colored('adding change for paragraph in notice', attrs=['bold']))
+                    if notice_paragraphs is None:
+                        print(colored('adding change for paragraph in notice\n', attrs=['bold']))
                         changeset = notice.find('.//{eregs}changeset')
                         change = etree.SubElement(changeset, 'change')
                         change.set('operation', 'modified')
                         change.set('label', label)
                         change.append(paragraph)
                     else:
-                        for notice_paragraph in notice_paragraphs:
-                            print(colored('replacing content in notice paragraph', attrs=['bold']))
-                            notice_content = notice_paragraph.find('.//{eregs}content')
-                            notice_paragraph.replace(notice_content, new_content)
+                        print(colored('replacing content in notice paragraph\n', attrs=['bold']))
+                        notice_content = notice_paragraph.find('.//{eregs}content')
+                        notice_paragraph.replace(notice_content, new_content)
 
         if problem_flag:
             print(colored('The tree has been altered! Do you want to write the result to disk?'))

--- a/tests/regulation_changes_tests.py
+++ b/tests/regulation_changes_tests.py
@@ -474,6 +474,40 @@ class ChangesTests(TestCase):
         self.assertEqual(new_ref.get('target'), '1234-3')
         self.assertEqual(new_ref.text, 'reference to 1234-1')
 
+    def test_process_changes_change_target_text(self):
+        notice_xml = etree.fromstring("""
+            <notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys><preamble></preamble>
+              <changeset>
+                <change operation="changeTarget" oldTarget="1234-1" newTarget="1234-3">reference to 1234-1</change>
+              </changeset>
+            </notice>""")
+        original_xml = etree.fromstring("""
+            <regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs ../../eregs.xsd">
+              <fdsys></fdsys>
+              <preamble></preamble>
+              <part label="1234">
+                <content>
+                  <subpart label="1234-Subpart-A">
+                    <content>
+                      <paragraph label="1234-1">An existing paragraph</paragraph>
+                    </content>
+                  </subpart>
+                  <subpart label="1234-Subpart-B">
+                    <content>
+                      <paragraph label="1234-2">Another existing paragraph with a
+                      <ref target="1234-1" reftype="internal">reference to 1234-1</ref></paragraph>
+                      <paragraph label="1234-3">One more existing paragraph with <ref target="1234-1" reftype="internal">another reference to 1234-1</ref></paragraph>
+                    </content>
+                  </subpart>
+                </content>
+              </part>
+            </regulation>""")
+        new_xml = process_changes(original_xml, notice_xml)
+        old_refs = new_xml.findall('.//{eregs}ref[@target="1234-1"]')
+        new_refs = new_xml.findall('.//{eregs}ref[@target="1234-3"]')
+        self.assertEqual(len(old_refs), 1)
+        self.assertEqual(len(new_refs), 1)
 
     def test_generate_diff_added(self):
         left_xml = etree.fromstring("""

--- a/tests/regulation_node_tests.py
+++ b/tests/regulation_node_tests.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+from unittest import TestCase
+
+import lxml.etree as etree
+
+from regulation.node import find_all_occurrences
+
+import settings
+
+class NodeTests(TestCase):
+
+    def test_find_all_occurrences(self):
+        s = "There are many days. Sunday is a day. Saturday is a day too. Days happen."
+        occurances = find_all_occurrences(s, 'day')
+        self.assertTrue(33 in occurances)
+        self.assertTrue(52 in occurances)
+        self.assertEqual(len(occurances), 2)
+        occurances = find_all_occurrences(s, 'days')
+        self.assertTrue(15 in occurances)
+        self.assertTrue(61 in occurances)
+        self.assertEqual(len(occurances), 2)
+

--- a/tests/regulation_node_tests.py
+++ b/tests/regulation_node_tests.py
@@ -12,7 +12,7 @@ import settings
 class NodeTests(TestCase):
 
     def test_find_all_occurrences(self):
-        s = "There are many days. Sunday is a day. Saturday is a day too. Days happen."
+        s = "There are many days. Sunday is a day. Saturday is a day too. Days happen.".lower()
         occurances = find_all_occurrences(s, 'day')
         self.assertTrue(33 in occurances)
         self.assertTrue(52 in occurances)


### PR DESCRIPTION
This PR makes two three changes to notices and term-checking:
1. Permits `changeTarget` notices changes to optionally specify a string and selectively change the target only for references that match that string.
2. Adds support to the term-checker for writing the results as changes in notice files (or modifying existing changes) rather than to the regulation file.
3. Modifies the term-matching function (`find_all_occurances()`) to look for word boundaries to prevent false-matches within other words.
