### PR TITLE
Single notice eCFR parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [![Build Status](https://travis-ci.org/cfpb/regulations-xml-parser.svg)](https://travis-ci.org/cfpb/regulations-xml-parser)
 
-Part of [eRegulations](http://eregs.github.io/eRegulations/).
+Part of [eRegulations](http://eregs.github.io/eRegulations/). 
 
-Parse [regulation XML](https://github.com/cfpb/regulations-schema) to
+Parse [Regulation XML](https://github.com/cfpb/regulations-schema) to
 generate JSON for [regulations-core](https://github.com/cfpb/regulations-core)
 to serve to [regulations-site](https://github.com/cfpb/regulations-site).
 
+A full development envinronment to perform all of these tasks can be set up using [regulations-bootstrap](https://github.com/cfpb/regulations-bootstrap).
 
 ## Usage
 
@@ -19,22 +20,36 @@ There are two types of RegML files:
 
 ### Generating RegML from eCFR
 
+Scenario: *You have a regulation and no RegML and you need to generate 
+the entire RegML history for that regulation.*
+
 To generate RegML from an eCFR XML file using
  [regulations-parser](https://github.com/cfpb/regulations-parser):
 
 ```shell
-./regml.py ecfr 12 [eCFR File]
+./regml.py ecfr parse-all [CFR title number] [eCFR file]
 ```
 
 This will generate the RegML `regulation` tree for the initial version
 and RegML `notice` trees with the necessary changeset for each
-subsequent version.
+subsequent version of the regulation based on notices published in the 
+Federal Register.
 
-If you want only want to output RegML for a single notice:
+### Generating RegML from a single eCFR Notice
+
+Scenario: *You have a regulation and a body of RegML for its history, 
+but a new final notice was published in the Federal Register.*
+
+To generate RegML from a single eCFR XML notice, you need to have a 
+RegML `regulation` file for the immediately prior notice. 
 
 ```shell
-./regml.py ecfr 12 [eCFR File] --only-notice [notice number]
+./regml.py ecfr parse-notice [CFR title number] [CFR part number] [notice document number] --applies-to [prior notice document number]
 ```
+
+This will generate the RegML `notice` changeset for the new notice. 
+That changeset can then be applied as described below to generate the 
+RegML `regulation` file.
 
 ## Generating RegML from `regulation` + `notice`
 

--- a/regml.py
+++ b/regml.py
@@ -939,7 +939,6 @@ def ecfr_notice(title, cfr_part, notice, applies_to, act_title,
 
     # Write the notice file
     if not without_notice:
-        print("writing notice file")
         builder.write_notice(version,
                              old_tree=old_tree,
                              reg_tree=reg_tree,
@@ -948,7 +947,6 @@ def ecfr_notice(title, cfr_part, notice, applies_to, act_title,
         
     # Write the regulation file for the new notice
     if with_version:
-        print("writing version")
         builder.write_regulation(new_tree, layers=layers)
     
 

--- a/regml.py
+++ b/regml.py
@@ -34,7 +34,8 @@ from regulation.changes import process_changes, process_analysis, generate_diff
 # Import regparser here with the eventual goal of breaking off the parts
 # we're using in the RegML parser into a library both can share.
 from regparser.federalregister import fetch_notice_json
-from regparser.builder import LayerCacheAggregator, tree_and_builder
+from regparser.builder import LayerCacheAggregator, tree_and_builder, Builder
+from regparser.notice.compiler import compile_regulation
 
 if (sys.version_info < (3, 0)):
     reload(sys)  # noqa
@@ -42,6 +43,17 @@ if (sys.version_info < (3, 0)):
 
 
 # Utility Functions ####################################################
+
+def base_path(is_notice=False):
+    """ Return the base RegML path based on our configuration. """
+    regml_base = settings.XML_ROOT
+    if is_notice:
+        regml_base = os.path.join(regml_base, 'notice')
+    else:
+        regml_base = os.path.join(regml_base, 'regulation')
+
+    return regml_base
+
 
 def find_file(file, is_notice=False, ecfr=False):
     """
@@ -63,18 +75,21 @@ def find_file(file, is_notice=False, ecfr=False):
             file = os.path.join(ecfr_base, file)
 
         else:
-            regml_base = settings.XML_ROOT
-            if is_notice:
-                regml_base = os.path.join(regml_base, 'notice')
-            else:
-                regml_base = os.path.join(regml_base, 'regulation')
-
-            file = os.path.join(regml_base, file)
-
+            file = os.path.join(base_path(is_notice=is_notice), file)
             if not file.endswith('.xml') and not os.path.isdir(file):
                 file += '.xml'
 
     return file
+
+
+def find_all(part, is_notice=False):
+    """ Find all regulation RegML files for the given part. 
+
+        If is_notice is True, all notice RegML files will be returned. """
+    regml_base = base_path(is_notice=is_notice)
+    regulation_pattern = os.path.join(regml_base, part, '*.xml')
+    files = glob.glob(regulation_pattern)
+    return files
 
 
 def find_version(part, notice, is_notice=False):
@@ -177,7 +192,7 @@ def generate_json(regulation_file, check_terms=False):
 
 # Main CLI Commands ####################################################
 
-# Create a general CLI that can take additional comments
+# Create a general CLI that can take additional commands
 @click.group()
 def cli():
     pass
@@ -301,8 +316,7 @@ def migrate_analysis(cfr_title, cfr_part):
     """ Migrate analysis from its context to top-level """
     
     # Migrate regulation files
-    regml_reg_dir = os.path.join(settings.XML_ROOT, 'regulation', cfr_part, '*.xml')
-    regml_reg_files = glob.glob(regml_reg_dir)
+    regml_reg_files = find_all(cfr_part)
     for reg_file in regml_reg_files:
         print(reg_file)
         file_name = os.path.join(reg_file)
@@ -315,8 +329,7 @@ def migrate_analysis(cfr_title, cfr_part):
         validator.validate_reg(xml_tree)
 
     # Migrate notices
-    regml_notice_dir = os.path.join(settings.XML_ROOT, 'notice', cfr_part, '*.xml')
-    regml_notice_files = glob.glob(regml_notice_dir)
+    regml_notice_files = find_all(cfr_part, is_notice=True)
     regml_notices = []
     for notice_file in regml_notice_files:
         print(notice_file)
@@ -377,8 +390,7 @@ def json_command(regulation_files, from_notices=[], check_terms=False):
               help="Suppresses output except for errors")
 def json_through(cfr_title, cfr_part, through=None, suppress_output=False):
     # Get list of available regs
-    regml_reg_dir = os.path.join(settings.XML_ROOT, 'regulation', cfr_part, '*.xml')
-    regml_reg_files = glob.glob(regml_reg_dir)
+    regml_reg_files = find_all(cfr_part)
 
     regml_regs = []
     regulation_files = []
@@ -496,8 +508,7 @@ def apply_notice(regulation_file, notice_file):
 def apply_through(cfr_title, cfr_part, through=None):
     # Get list of notices that apply to this reg
     # Look for locally available notices
-    regml_notice_dir = os.path.join(settings.XML_ROOT, 'notice', cfr_part, '*.xml')
-    regml_notice_files = glob.glob(regml_notice_dir)
+    regml_notice_files = find_all(cfr_part, is_notice=True)
 
     regml_notices = []
     for notice_file in regml_notice_files:
@@ -729,9 +740,7 @@ def versions(title, part, from_fr=False, from_regml=True):
             print("\t\tinitially effective on", notice['effective_on'])
 
     # Look for locally available notices
-    regml_notice_dir = os.path.join(settings.XML_ROOT, 'notice', part, '*.xml')
-    regml_notice_files = glob.glob(regml_notice_dir)
-    # regml_notice_files = os.listdir(regml_notice_dir)
+    regml_notice_files = find_all(part, is_notice=True)
     print(colored("RegML Notices are available for:", attrs=['bold']))
     regml_notices = []
     for notice_file in regml_notice_files:
@@ -768,8 +777,14 @@ def versions(title, part, from_fr=False, from_regml=True):
 
 # eCFR Convenience Commands ############################################
 
-# Wrap the eCFR parser as a library for the purposes of our workflow
-@cli.command()
+# Create a general ecfr group that can take additional commands
+@cli.group()
+def ecfr():
+    pass
+
+# Wrap the eCFR parser as a library for the purposes of our workflow.
+# This is equivalent to build_from.py
+@ecfr.command('parse-all')
 @click.argument('title', type=int)
 @click.argument('file')
 @click.option('--act-section', default=0, type=int)
@@ -782,7 +797,7 @@ def versions(title, part, from_fr=False, from_regml=True):
               help="do not output any notice changesets")
 @click.option('--only-notice', default=None,
               help="only write output for this notice number")
-def ecfr(title, file, act_title, act_section,
+def ecfr_all(title, file, act_title, act_section,
          with_all_versions=False, without_versions=False,
          without_notices=False, only_notice=None):
     """ Parse eCFR into RegML """
@@ -827,6 +842,81 @@ def ecfr(title, file, act_title, act_section,
         last_version = version
         del last_notice, old, new_tree, notices     # free some memory
 
+
+@ecfr.command('parse-notice')
+@click.argument('title', type=int)
+@click.argument('cfr_part')
+@click.argument('notice')
+@click.option('--applies-to',
+              help="document number to which the new notice applies")
+@click.option('--act-section', default=0, type=int)
+@click.option('--act-title', default=0, type=int)
+@click.option('--with-version', is_flag=True,
+              help="output the full reg tree version")
+@click.option('--without-notice', is_flag=True, 
+              help="output the notice changeset")
+def ecfr_notice(title, cfr_part, notice, applies_to, act_title,
+        act_section, with_version=False, without_notice=False):
+    """ Generate RegML for a single notice from eCFR XML. """
+
+    # Get the notice the new one applies to
+    with open(find_file(os.path.join(cfr_part, applies_to)), 'r') as f:
+        reg_xml = f.read()
+    parser = etree.XMLParser(huge_tree=True)
+    xml_tree = etree.fromstring(reg_xml, parser)
+    doc_number = xml_tree.find('.//{eregs}documentNumber').text
+            
+    # Validate the file relative to schema
+    validator = get_validator(xml_tree)
+
+    # Get the ecfr builder
+    builder = Builder(cfr_title=title,
+                      cfr_part=cfr_part,
+                      doc_number=doc_number,
+                      checkpointer=None,
+                      writer_type='XML')
+
+    # Fetch the notices from the FR API and find the notice we're
+    # looking for
+    builder.fetch_notices_json()
+    notice_json = next((n for n in builder.notices_json 
+                        if n['document_number'] == notice))
+
+    # Build the notice
+    notice = builder.build_single_notice(notice_json)[0]
+
+    if 'changes' not in notice:
+        print('There are no changes in this notice to apply.')
+        return
+
+    # We've successfully fetched and parsed the new notice.
+    # Build a the reg tree and layers for the notice it applies to.
+    old_tree = build_reg_tree(xml_tree)
+
+    # Build the new reg tree from the old_tree + notice changes
+    last_version = doc_number
+    version = notice['document_number']
+    merged_changes = builder.merge_changes(version, notice['changes'])
+    reg_tree = compile_regulation(old_tree, merged_changes)
+    layer_cache = LayerCacheAggregator()
+    layers = builder.generate_layers(reg_tree,
+                                     [act_title, act_section],
+                                     layer_cache)
+
+    # Write the notice file
+    if not without_notice:
+        print("writing notice file")
+        builder.write_notice(version,
+                             old_tree=old_tree,
+                             reg_tree=reg_tree,
+                             layers=layers,
+                             last_version=last_version)
+        
+    # Write the regulation file for the new notice
+    if with_version:
+        print("writing version")
+        builder.write_regulation(new_tree, layers=layers)
+    
 
 if __name__ == "__main__":
     cli()

--- a/regulation/node.py
+++ b/regulation/node.py
@@ -44,7 +44,7 @@ class RegNode:
         self.depth = 0
 
         self.mixed_text = []
-        self.source_xml = ''
+        self.source_xml = None
 
         if 'include_children' in kwargs:
             if not (kwargs['include_children'] is True or

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -138,7 +138,7 @@ def build_reg_tree(root, parent=None, depth=0):
 
         node.node_type = parent.node_type
         node.mixed_text = xml_mixed_text(content)
-        node.source_xml = etree.tostring(root, encoding='UTF-8')
+        node.source_xml = root
 
         children = root.findall('{eregs}paragraph')
 
@@ -223,7 +223,7 @@ def build_reg_tree(root, parent=None, depth=0):
         node.label = root.get('label').split('-')
         node.text = content_text
         node.node_type = 'interp'
-        node.source_xml = etree.tostring(root, encoding='UTF-8')
+        node.source_xml = root
 
         children = root.findall('{eregs}interpParagraph')
 


### PR DESCRIPTION
This PR adds support for parsing a single notice with the eCFR parser.

The use-case for this is: we have regulations that are fully RegML’ed now. Suppose a new notice is issued that applies to X. We don’t want to have to parse the entire history of X to get a new notice RegML file for the latest notice.

This PR adds an `ecfr parse-notice` command that will parse a given notice document number and apply it to a given RegML regulation document number. So you would run 

```
./regml.py ecfr parse-notice 12 1024 [NEW DOC NUMBER] —applies-to [LAST REGML DOC NUMBER]
```

And it would generate a new notice XML file from a parse of that new notice from the Federal Register.

This is done by parsing the given RegML regulation file and creating a `RegNode` tree and passing that to the eCFR parser as the old tree. 

This has some holes, notably the table processing of the eCFR parser’s formatting layer expect the eCFR XML to be attached to the `Node`, and clearly it can’t be when reading from RegML.

The README is updated for this change.
