### PR TITLE
Support keyterms in interp paragraphs

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -784,9 +784,9 @@ def build_toc_layer(root):
 
 def build_keyterm_layer(root):
     """
-    Build the keyterm layer from the provided root of the XML tree.
+    Build the keyterm layer from the provided XML tree.
 
-    :param root: The root element of the XML tree.
+    :param root: The root element of an XML tree containing paragraphs.
     :type root: :class:`etree.Element`
 
     :return: An OrderedDict containing the locations of keyterms, suitable for direct
@@ -795,24 +795,19 @@ def build_keyterm_layer(root):
     """
 
     keyterm_dict = OrderedDict()
+    paragraphs = root.findall('.//{eregs}paragraph') \
+               + root.findall('.//{eregs}interpParagraph')
 
-    subparts = root.findall('.//{eregs}subpart')
-    appendices = root.findall('.//{eregs}appendix')
-
-    paragraph_locations = subparts + appendices
-
-    for element in paragraph_locations:
-        paragraphs = element.findall('.//{eregs}paragraph')
-        for paragraph in paragraphs:
-            title = paragraph.find('{eregs}title')
-            if title is not None and title.get('type') == 'keyterm':
-                label = paragraph.get('label')
-                keyterm_dict[label] = [
-                    {
-                        'key_term': title.text,
-                        'locations': [0]
-                    }
-                ]
+    for paragraph in paragraphs:
+        title = paragraph.find('{eregs}title')
+        if title is not None and title.get('type') == 'keyterm':
+            label = paragraph.get('label')
+            keyterm_dict[label] = [
+                {
+                    'key_term': title.text,
+                    'locations': [0]
+                }
+            ]
 
     return keyterm_dict
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -213,8 +213,14 @@ def build_reg_tree(root, parent=None, depth=0):
         title = root.find('{eregs}title')
         content = apply_formatting(root.find('{eregs}content'))
         content_text = xml_node_text(content)
+
         if title is not None:
-            node.title = title.text
+            if title.get('type') != 'keyterm':
+                node.title = title.text
+            else:
+                # Keyterms are expected by reg-site to be included in
+                # the content text rather than the title of a node.
+                content_text = title.text + content_text
 
         node.marker = root.get('marker', '')
         if node.marker == 'none':

--- a/tests/common.py
+++ b/tests/common.py
@@ -47,6 +47,7 @@ test_xml = """
                 <interpSection label="1234-1-Interp" target="1234-1">
                   <title>Introduction</title>
                   <interpParagraph label="1234-1-A-Interp" target="1234-1-A">
+                    <title type="keyterm">An initial keyterm</title>
                     <content>Some interpretation content here.</content>
                   </interpParagraph>
                   <interpParagraph label="1234-1-A-Interp-1">

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -15,7 +15,8 @@ from regulation.tree import (build_reg_tree,
                              build_notice,
                              build_formatting_layer,
                              apply_formatting,
-                             build_toc_layer)
+                             build_toc_layer,
+                             build_keyterm_layer)
 from regulation.node import RegNode
 
 
@@ -670,4 +671,65 @@ class TreeTestCase(TestCase):
                                                                    (u'term', 'bureau')]))])
                                         )])
 
+        self.assertEqual(expected_result, result)
+
+    def test_build_keyterm_layer_subpart(self):
+        """ Make sure subpart paragraphs with keyterms are properly
+            recognized """
+        tree = etree.fromstring("""
+        <section label="1234-1" xmlns="eregs">
+          <paragraph label="1234-1-a" marker="a">
+           <title type="keyterm">Keyterm.</title>
+            <content>I'm a paragraph</content>
+          </paragraph>
+        </section>
+        """)
+        expected_result = {
+            '1234-1-a': [
+                {'locations': [0], 
+                 'key_term': 'Keyterm.'}
+            ],
+        }
+        result = build_keyterm_layer(tree)
+        self.assertEqual(expected_result, dict(result))
+
+    def test_build_keyterm_layer_appendix(self):
+        """ Make sure appendix paragraphs with keyterms are properly
+            recognized """
+        tree = etree.fromstring("""
+        <appendixSection appendixSecNum="1" label="1234-A-p1" xmlns="eregs">
+          <subject/>
+            <paragraph label="1234-A-1" marker="1">
+              <title type="keyterm">Keyterm.</title>
+              <content>I'm a paragraph</content>
+            </paragraph>
+        </appendixSection>
+        """)
+        expected_result = {
+            '1234-A-1': [
+                {'locations': [0], 
+                 'key_term': 'Keyterm.'}
+            ],
+        }
+        result = build_keyterm_layer(tree)
+        self.assertEqual(expected_result, result)
+
+    def test_build_keyterm_layer_interp(self):
+        """ Make sure interpParagraphs with keyterms are properly
+            recognized """
+        tree = etree.fromstring("""
+        <interpSection label="1234-1-Interp" target="1234-1" xmlns="eregs">
+          <interpParagraph label="1234-1-A-Interp" target="1234-1-A">
+            <title type="keyterm">Keyterm.</title>
+            <content>Some interpretation content here.</content>
+          </interpParagraph>
+        </interpSection>
+        """)
+        expected_result = {
+            '1234-1-A-Interp': [
+                {'locations': [0], 
+                 'key_term': 'Keyterm.'}
+            ],
+        }
+        result = build_keyterm_layer(tree)
         self.assertEqual(expected_result, result)


### PR DESCRIPTION
This PR adds support for keyterms in `interpParagraph` elements by refactoring the keyterm layer builder slightly. Previously it restricted the location of keyterm-containing elements to `subpart` and `appendix` ancestors. Now, we just look for `paragraph` and `interpParagraph`, which are allowed `title` elements that are keyterms by the schema. 
