### PR TITLE
interpParagraphs should get keyterm offsets, just not marker offsets

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -1147,8 +1147,7 @@ def get_offset(element, marker='', title=None):
     # Note: reg-site treats some elements (e.g. interpParagraphs)
     # as "special" — they don't get the keyterm text included,
     # so we don't include an offset here.
-    if title is not None and title.get('type') == 'keyterm' and \
-            element.tag not in TAGS_WITHOUT_OFFSETS:
+    if title is not None and title.get('type') == 'keyterm':
         keyterm_offset = len(title.text)
     else:
         keyterm_offset = 0

--- a/tests/regulation_tree_tests.py
+++ b/tests/regulation_tree_tests.py
@@ -16,7 +16,8 @@ from regulation.tree import (build_reg_tree,
                              build_formatting_layer,
                              apply_formatting,
                              build_toc_layer,
-                             build_keyterm_layer)
+                             build_keyterm_layer, 
+                             get_offset)
 from regulation.node import RegNode
 
 
@@ -746,3 +747,32 @@ class TreeTestCase(TestCase):
         }
         result = build_keyterm_layer(tree)
         self.assertEqual(expected_result, result)
+
+    def test_get_offset(self):
+        """ Make sure offsets returned are correct """
+        element = etree.fromstring("""
+          <paragraph xmlns="eregs" marker="(1)">
+            <title type="keyterm">Keyterm.</title>
+            <content>Some content here.</content>
+          </paragraph>
+        """)
+        marker = "(1)"
+        title = etree.fromstring("""
+          <title type="keyterm">Keyterm.</title>
+        """)
+        result = get_offset(element, marker, title)
+        self.assertEqual(12, result)
+
+        element = etree.fromstring("""
+          <interpParagraph xmlns="eregs" marker="(1)">
+            <title type="keyterm">Keyterm.</title>
+            <content>Some content here.</content>
+          </interpParagraph>
+        """)
+        marker = "(1)"
+        title = etree.fromstring("""
+          <title type="keyterm">Keyterm.</title>
+        """)
+        result = get_offset(element, marker, title)
+        self.assertEqual(8, result)
+        


### PR DESCRIPTION
Previously interpParagraphs didn’t get keyterms at all. #63 fixed that, but left the keyterm offset exception. This PR fixes that.
