### PR TITLE
Match notice indexes between apply-through and json-through

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -542,12 +542,12 @@ def json_through(cfr_title, cfr_part, through=None, suppress_output=False):
     print(colored("\nAvailable RegML documents for reg {}:".format(cfr_part),
           attrs=['bold']))
     for kk in range(len(regml_regs)):
-        print("{0:>3}. {1[0]:<22}(Effective: {1[1]})".format(kk+1,
+        print("{0:>3}. {1[0]:<22}(Effective: {1[1]})".format(kk,
                                                              regml_regs[kk]))
     print()
 
     # Possible answers are blank (all), the numbers, or the doc names
-    possible_indices = [str(kk+1) for kk in range(len(regml_regs))]
+    possible_indices = [str(kk) for kk in range(len(regml_regs))]
     possible_regs = [nn[0] for nn in regml_regs]
 
     # If number is supplied, use that one
@@ -563,7 +563,7 @@ def json_through(cfr_title, cfr_part, through=None, suppress_output=False):
 
     if len(answer) == 0:
         # Apply JSON to all documents
-        last_ver_idx = len(regml_regs)
+        last_ver_idx = len(regml_regs) - 1
     elif answer in possible_indices:
         # Apply through answer
         last_ver_idx = int(answer)
@@ -577,13 +577,13 @@ def json_through(cfr_title, cfr_part, through=None, suppress_output=False):
         return
 
     print(colored("\nApplying JSON through {0[0]}\n".format(
-                  regml_regs[last_ver_idx-1]),
+                  regml_regs[last_ver_idx]),
           attrs=['bold']))
 
     # Perform the json application process
     # Unlike apply-through, since json outputs its own command line output, here we
     # reuse the existing json structure
-    json_command(regulation_files[:last_ver_idx])
+    json_command(regulation_files[:last_ver_idx+1])
 
 
 # Given a notice, apply it to a previous RegML regulation verson to


### PR DESCRIPTION
This PR makes the notice index the same in apply-through and son-through. Example:

```
$ ./regml.py apply-through 12 1026

Available notices for reg 1026:
  0. 2011-31715            (Initial version)
  1. 2012-28341            (Effective: 2012-11-23)
  2. 2012-27993            (Effective: 2013-01-01)
  3. 2012-27997            (Effective: 2013-01-01)
  4. 2013-07066            (Effective: 2013-03-28)

Press enter to apply all or enter notice number: [all] 3

Applying notices through 2012-27997
```

```
$ ./regml.py json-through 12 1026 

Available RegML documents for reg 1026:
  0. 2011-31715            (Effective: 2011-12-30)
  1. 2012-28341            (Effective: 2012-11-23)
  2. 2012-27993            (Effective: 2013-01-01)
  3. 2012-27997            (Effective: 2013-01-01)
  4. 2013-07066            (Effective: 2013-03-28)

Press enter to apply all or enter document number: [all] 3
Answer: '3'

Applying JSON through 2012-27997
```
