### PR TITLE
Fix the test for child elements other than content, add tests

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -19,8 +19,7 @@ from lxml import etree
 # This array contains tag types that can exist in a paragraph
 # that are not part of paragraph text.
 # E.g. tags like <ref> are part of the paragraph text.
-NON_PARA_SUBELEMENT = ['{eregs}paragraph',
-                       '{eregs}callout',
+NON_PARA_SUBELEMENT = ['{eregs}callout',
                        '{eregs}table',
                        '{eregs}graphic']
 
@@ -1097,13 +1096,18 @@ def is_intro_text(item):
     :return: A boolean where True indicates the element is an intro paragraph.
     :rtype: boolean
     """
-    if item.find('{eregs}title') is None and item.get('marker') == '':
+    if item.find('{eregs}title') is None and \
+            item.get('marker') == '' and \
+            len(item) == 1:
         # Only the first child may be an intro text item
         child_num = item.getparent().index(item)
         if child_num > 1:
             return False
-        # Note: item[0] is always a <content> tag - check that element's children
-        if len(filter(lambda child: child.tag in NON_PARA_SUBELEMENT, item[0].getchildren())) == 0:
+
+        # Note: item[0] is always a <content> tag - check that 
+        # element's children
+        if len(filter(lambda child: child.tag in NON_PARA_SUBELEMENT, 
+                      item[0].getchildren())) == 0:
             return True
 
     return False


### PR DESCRIPTION
This PR fixes the `is_intro_text()` test for child paragraphs. In the case that a paragraph has no marker, no title, AND has subparagraphs, it would fail to detect the subparagraphs and they would be discarded entirely.

This fixes that problem and adds a test case that tests each condition that an intro paragraph must meet. The `has_children` test element demonstrates the sort of paragraph that was testing `True` when it should’ve been `False`.

Review: @hillaryj @grapesmoker 
