### PR TITLE
allow apply-through pipeline to check notices for missing references

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -639,7 +639,15 @@ def apply_notice(regulation_file, notice_file):
 @click.option('--through',
               help="Skips prompt and applies notices through given notice number " +
                    "(e.g. --through YYYY-#####")
-def apply_through(cfr_title, cfr_part, through=None):
+@click.option('--fix-notices',
+              help="If set to True, use the validator to fix notices as you apply them.")
+@click.option('--skip-fix-notices', multiple=True,
+              help="Document numbers of notices to skip. Specify this multiple times because"
+                   "nargs='*' doesn't work in click.")
+@click.option('--skip-fix-notices-through',
+              help='Skip fixing notices through the specified document number.')
+def apply_through(cfr_title, cfr_part, through=None, fix_notices=False,
+                  skip_fix_notices=[], skip_fix_notices_through=None):
     # Get list of notices that apply to this reg
     # Look for locally available notices
     regml_notice_files = find_all(cfr_part, is_notice=True)
@@ -763,7 +771,33 @@ def apply_through(cfr_title, cfr_part, through=None):
 
         # Validate the files
         regulation_validator = get_validator(prev_tree)
+        terms_layer = build_terms_layer(prev_tree)
         notice_validator = get_validator(notice_xml)
+
+        # validate the notice XML with the layers derived from the
+        # tree of the previous version
+        reload_notice = False
+        skip_notices = list(skip_fix_notices)
+
+        if skip_fix_notices_through is not None:
+            if skip_fix_notices_through in possible_notices:
+                last_fix_idx = possible_notices.index(skip_fix_notices_through)
+                skip_notices.extend(possible_notices[:last_fix_idx + 1])
+
+        if fix_notices and doc_number not in skip_notices:
+            print('Fixing notice number {}:'.format(doc_number))
+            notice_validator.validate_terms(notice_xml, terms_layer)
+            notice_validator.validate_term_references(notice_xml, terms_layer, notice_file)
+            notice_validator.fix_omitted_cites(notice_xml, notice_file)
+            reload_notice = True
+
+        # at this point the file has possibly changed, so we should really reload it
+        if reload_notice:
+            with open(notice_file, 'r') as f:
+                notice_string = f.read()
+            parser = etree.XMLParser(huge_tree=True)
+
+            notice_xml = etree.fromstring(notice_string, parser)
 
         # Process the notice changeset
         try:

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -928,7 +928,7 @@ def build_analysis(root):
     """
 
     analysis_dict = OrderedDict()
-
+    doc_number = root.find('{eregs}preamble').find('{eregs}documentNumber').text
     # Find the analysis element
     analysis_elm = root.find('.//{eregs}analysis')
     if analysis_elm is None:
@@ -945,7 +945,7 @@ def build_analysis(root):
         # Warn user about analysisSection elements without labels/attributes
         if label is None or document_number is None or publication_date is None:
             err_info = {"label": label, "notice": document_number, "date": publication_date}
-            raise ValueError("analysisSection element is missing attribute information:\n{}".format(err_info))
+            raise ValueError("In {}, analysisSection element is missing attribute information:\n{}".format(doc_number, err_info))
 
         # Labels might have multiple analysis refs. If it's not already
         # in the analyses_dict, add it.

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -110,7 +110,8 @@ class EregsValidator:
                     'XML Validated!', severity=Severity(Severity.OK))
                 self.events.append(validation_ok)
             except Exception as ex:
-                msg = 'Error validating regs XML!: {}'.format(ex)
+                doc_number = tree.find('{eregs}preamble').find('{eregs}documentNumber').text
+                msg = 'Error validating regs XML for part {}!: {}'.format(doc_number, ex)
                 validation_ex = EregsValidationEvent(
                     msg, severity=Severity(Severity.CRITICAL))
                 self.events.append(validation_ex)

--- a/settings.py
+++ b/settings.py
@@ -21,7 +21,7 @@ XML_ROOT = '../regulations-xml'
 # 
 # This should generally be a clone or fork of 
 # https://github.com/cfpb/regulations-stub
-JSON_ROOT = '../regulations-stub/stub/'
+JSON_ROOT = '../regulations-xml-json'
 
 # SPECIAL_SINGULAR_NOURS provides overrides for singular nouns that the
 # inflect module has problems with. 

--- a/settings.py
+++ b/settings.py
@@ -21,7 +21,7 @@ XML_ROOT = '../regulations-xml'
 # 
 # This should generally be a clone or fork of 
 # https://github.com/cfpb/regulations-stub
-JSON_ROOT = '../regulations-xml-json'
+JSON_ROOT = '../regulations-stub/stub/'
 
 # SPECIAL_SINGULAR_NOURS provides overrides for singular nouns that the
 # inflect module has problems with. 


### PR DESCRIPTION
Uses the terms layer of the previous version to validate the term references in the next notice, thereby fixing references that are missing from hand-corrected notices. Also checks for missing internal references in notices.
