### PR TITLE
Add pinned pyparsing version to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==6.2
 enum34==1.1.2
 inflect==0.2.5
 lxml==3.5.0
+pyparsing==1.5.7
 termcolor==1.1.0
 -e git+https://github.com/cfpb/regulations-configs.git#egg=regulations_configs
 -e git+https://github.com/cfpb/regulations-parser@xml-writer-devel#egg=regulations_parser


### PR DESCRIPTION
The `regml.py` script includes code that tries to import `getTokensEndLoc` from the [pyparsing](https://pypi.python.org/pypi/pyparsing) module, but this seems to have been deprecated in the most recent versions of that package.

The `requirements.txt` file in https://github.com/cfpb/regulations-parser/ [has a pinned version to `pyparsing==1.5.7`](https://github.com/cfpb/regulations-parser/blob/master/requirements.txt#L2), but the setup.py file in that repo [does not](https://github.com/cfpb/regulations-parser/blob/master/setup.py#L22). So doing a clean install of just regulations-xml-parser and doing `pip install -r requirements.txt` there will just download the latest pyparsing, which breaks things and prevents `regml.py` from running.

This would work if you already had the correct version of pyparsing installed through some other means, but not if installing cleanly.

This change just adds the pinned version of `pyparsing==1.5.7`to this project's `requirements.txt` file so that it can be used in isolation if that package isn't already installed.

All unit tests continue to pass via `tox` with this change.