### PR TITLE
Modify settings to default to local XSD_FILE

### DIFF
--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -85,14 +85,14 @@ class EregsValidator:
         :return: :class:`etree.XMLSchema`: the schema object used to validate the reg.
         """
         try:
-            schema = etree.XMLSchema(file=self.xsd_file)
-
-        except Exception as ex:
-            cprint('Exception occurred when reading file: {0!s}'.format(
-                ex), 'red')
-            return None
-
-        return schema
+            return etree.XMLSchema(file=self.xsd_file)
+        except etree.XMLSchemaParseError:
+            cprint(
+                'Error occurred when reading schema file {}; did you forget '
+                'to set settings.XSD_FILE to a local or remote path '
+                'containing the eregs schema?'.format(self.xsd_file), 'red'
+            )
+            raise
 
     def validate_reg(self, tree):
         """

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 coverage==4.0.3
 flake8==2.5.0
+GitPython==2.1.5
 mccabe==0.3.1
 mock==1.3.0
 nose==1.3.7

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,11 @@
 import os
 
-# XSD_FILE provides the local path or URL to the RegML schema file.
-# The schema is available at http://cfpb.github.io/regulations-schema/src/eregs.xsd
+# XSD_FILE provides the local path or URL (HTTP, FTP) to the RegML schema file.
+# Schema documentation is available at http://cfpb.github.io/regulations-schema
 #
 # A local copy should generally be a clone or fork of
 # https://github.com/cfpb/regulations-schema
-XSD_FILE = 'http://cfpb.github.io/regulations-schema/src/eregs.xsd'
+XSD_FILE = '../regulations-schema/src/eregs.xsd'
 
 # XML_ROOT is the path to Regulations XML files that this parser is
 # intended to parse. Files in this location are expected to be stored

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     -rrequirements.txt
     -rrequirements_test.txt
 commands =
-    nosetests tests --with-coverage
+    nosetests tests --with-coverage --cover-package=regulation
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This change modifies `settings.py` so that the `XSD_FILE` setting defaults to a local directory as opposed to a copy of the schema hosted on GitHub. This is necessary because lxml's URL-based loading doesn't properly handle HTTPS URLs.

The new setting assumes a default of the schema repo checked out at the same level as this repo, e.g. `../regulations-schema`. When the validator schema is loaded, if the main schema file does not exist, a descriptive error will be displayed to the user:

> Error occurred when reading schema file ../regulations-schema/src/eregs.xsd; did you forget to set settings.XSD_FILE to a local or remote path containing the eregs schema?

and the program will raise an exception and exit. This same error occurs if the schema file is invalid somehow.

Some new unit tests have been added to validate this behavior. Because the unit tests need the schema to test validation, the tests for the validator now clone the GitHub repo locally before testing. This is somewhat suboptimal but necessary for running in an automated way, e.g.
on Travis. This only happens once for the test class, not per test, and things are cleaned up when the tests end.

Run `tox` to verify that test behavior works even without a preexisting local copy of the schema.

(Somewhat unrelated, but I also slightly modified how the unit tests are invoked by Tox so that coverage statistics only show the relevant package.)