### PR TITLE
Remove pinned non-master branch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ lxml==3.5.0
 pyparsing==1.5.7
 termcolor==1.1.0
 -e git+https://github.com/cfpb/regulations-configs.git#egg=regulations_configs
--e git+https://github.com/cfpb/regulations-parser@xml-writer-devel#egg=regulations_parser
+-e git+https://github.com/cfpb/regulations-parser#egg=regulations_parser


### PR DESCRIPTION
Reference to xml-writer-devel branch is obsolete as those changes have been moved into master.