### PR TITLE
Add support for 1040 reg "letter"

### DIFF
--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -773,7 +773,7 @@ def build_toc_layer(root):
             parent = parent.getparent()
 
         label = parent.get('label')
-        
+
         # Warn user about elements without labels
         if label is None:
             raise ValueError("TOC parent element {} has no label; this will cause JSON issues.".format(parent.tag))
@@ -787,7 +787,7 @@ def build_toc_layer(root):
             toc_entry = {'index': target, 'title': subject}
             toc_dict[label].append(toc_entry)
 
-        # Build appendix sections 
+        # Build appendix sections
         for appendix_section in toc.findall('{eregs}tocAppEntry'):
             target = appendix_section.get('target').split('-')
             subject = appendix_section.find('{eregs}appendixSubject').text
@@ -858,6 +858,7 @@ def build_meta_layer(root):
                       '1022': 'V', '1023': 'W', '1024': 'X',
                       '1025': 'Y', '1026': 'Z', '1027': 'AA',
                       '1028': 'BB', '1029': 'CC', '1030': 'DD',
+                      '1040': '1040',
                       }
 
     preamble = root.find('{eregs}preamble')
@@ -1114,9 +1115,9 @@ def is_intro_text(item):
         if child_num > 1:
             return False
 
-        # Note: item[0] is always a <content> tag - check that 
+        # Note: item[0] is always a <content> tag - check that
         # element's children
-        if len(filter(lambda child: child.tag in NON_PARA_SUBELEMENT, 
+        if len(filter(lambda child: child.tag in NON_PARA_SUBELEMENT,
                       item[0].getchildren())) == 0:
             return True
 


### PR DESCRIPTION
This change adds support for regulation 1040 to the `json-through` command. This command uses a lookup table to determine what should be entered into the "regLetter" section of the RegML schema.

Regulation 1040 (arbitration reg) doesn't have a letter, but should be referred to as "Regulation 1040", so this change just adds a hardcoded 1040 -> 1040 mapping.

To validate, run

```sh
./regml.py json-through 12 1040
```

to generate eRegs JSON from 1040 RegML.