### PR TITLE
Return non-zero exit code when validate fails

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -139,7 +139,7 @@ def get_validator(xml_tree, raise_instead_of_exiting=False):
         if raise_instead_of_exiting:
             raise event
         else:
-            sys.exit(0)
+            sys.exit(int(validator.has_critical_errors))
 
     return validator
 

--- a/regml.py
+++ b/regml.py
@@ -256,7 +256,9 @@ def validate(file, no_terms=False, no_citations=False, no_keyterms=False):
     if xml_tree.tag == '{eregs}notice':
         pass
 
-    return validator
+    if validator.has_critical_errors:
+        print('Validation failed with critical errors.')
+        sys.exit(1)
 
 
 @cli.command('check-terms')

--- a/regulation/validation.py
+++ b/regulation/validation.py
@@ -648,10 +648,11 @@ class EregsValidator:
 
     @property
     def is_valid(self):
-        for error in self.events:
-            if error.severity != Severity.OK:
-                return False
-        return True
+        return all(e.severity == Severity.OK for e in self.events)
+
+    @property
+    def has_critical_errors(self):
+        return any(e.severity == Severity.CRITICAL for e in self.events)
 
     def validate_interp_targets(self, tree, regulation_file, label=None):
         """

--- a/tests/test_regml.py
+++ b/tests/test_regml.py
@@ -1,0 +1,49 @@
+import os
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from regml import validate
+
+
+class TestValidateCommand(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestValidateCommand, cls).setUpClass()
+        with NamedTemporaryFile(delete=False) as f:
+            f.write('<xml></xml>')
+            cls.tempfile = f.name
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.tempfile)
+        super(TestValidateCommand, cls).tearDownClass()
+
+    def test_invalid_filename_raises_ioerror(self):
+            with self.assertRaises(IOError):
+                validate(['nonexistent filename'])
+
+    def test_valid_file_returns_successfully(self):
+        with patch(
+            'regml.EregsValidator',
+            return_value=Mock(has_critical_errors=False)
+        ):
+            try:
+                validate([self.tempfile])
+            except SystemExit as e:
+                self.assertEqual(e.code, 0)
+            else:
+                self.fail('invalid files should exit with code 0')
+
+    def test_invalid_file_exits_with_code_1(self):
+        with patch(
+            'regml.EregsValidator',
+            return_value=Mock(has_critical_errors=True)
+        ):
+            try:
+                validate([self.tempfile])
+            except SystemExit as e:
+                self.assertEqual(e.code, 1)
+            else:
+                self.fail('invalid files should exit with code 1')


### PR DESCRIPTION
The `validate` option in `regml.py` should always return a non-zero exit code when validation fails with critical errors. This change retains the existing default behavior when you run

`./regml.py validate /path/to/regml.xml`

where all errors (info, warning, or otherwise) are printed to the screen, but now exits with status code 1 if critical errors are encountered.

Various unit tests have been added to support this change.

This change is intended to properly enable what was attempted in https://github.com/cfpb/regulations-xml/pull/25, that is, automated checking of valid RegML.