### PR TITLE
Sequencing notices and fixing missing internal references

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -184,7 +184,6 @@ def extract_notice_file_meta(notice_file):
         return
 
     return Notice(doc_number, effective_date, applies_to_doc_number, applies_to_eff_date, file_name)
-    #return (doc_number, effective_date, applies_to_doc_number, file_name)
 
 
 def write_layer(layer_object, reg_number, notice, layer_type,
@@ -883,11 +882,6 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
         regml_dependency_chain[notice] = set(applies_to)
 
     sorted_notices = [list(notice)[0] for notice in list(toposort(regml_dependency_chain))]
-    import pprint
-    pprint.pprint(regml_notice_files)
-    pprint.pprint(regml_notices)
-    pprint.pprint(regml_dependency_chain)
-    pprint.pprint(list(toposort(regml_dependency_chain)))
     doc_counts = Counter([notice.document_number for notice in sorted_notices])
 
     # If no notices found, issue error message

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -869,7 +869,7 @@ def build_meta_layer(root):
     statutory_name = fdsys.find('{eregs}title').text
     part = preamble.find('{eregs}cfr').find('{eregs}section').text
 
-    part_letter = part_to_letter[part]
+    part_letter = part_to_letter.get(part, part)
 
     meta_dict[part] = [
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ inflect==0.2.5
 lxml==3.5.0
 pyparsing==1.5.7
 termcolor==1.1.0
+toposort==1.5
 -e git+https://github.com/cfpb/regulations-configs.git#egg=regulations_configs
 -e git+https://github.com/cfpb/regulations-parser#egg=regulations_parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ lxml==3.5.0
 pyparsing==1.5.7
 termcolor==1.1.0
 toposort==1.5
+python-dateutil==2.6.1
 -e git+https://github.com/cfpb/regulations-configs.git#egg=regulations_configs
 -e git+https://github.com/cfpb/regulations-parser#egg=regulations_parser


### PR DESCRIPTION
This PR does two things.

First, it makes use of the `leftEffectiveDate` field to sequence notice application. This makes it possible to define an explicit dependency chain using both this property and the `leftDocumentNumber` property of a changeset. The problem that this solves is one where there exist multiple effective dates for a single notice; in that case, merely specifying `leftDocumentNumber` is insufficient to build the notice dependency chain. In the past, this was solved by attaching a date to the document number, e.g. `2016-24503_20180401`. This is still the case for _file names_ but it unnecessarily couples together two fields which should be independent. This also adds a new dependency called `toposort` which implements a topological sort on the dependency chain.

This change only affects the `apply-through` command, as that is the command that executes the sequential compilation of notices into regulation version. A good way to test this is to run `./regml.py apply-through 12 1026`, which will display all the notices of reg Z in chronological order of application. There should be 50 notices, including "version 0" which is the first notice that contains the original version of the reg.

Second, this PR adds the command line functionality to run `fix_omitted_cites`. This function catches missing references to internal parts of the reg of the form e.g. 1003.5(a)(1) etc. It had already existed but wasn't callable from the command line.