### PR TITLE
Break up reg into sections

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -759,9 +759,11 @@ def generate_diff_xml(cfr_part, versions=None):
                    "nargs='*' doesn't work in click.")
 @click.option('--skip-fix-notices-through',
               help='Skip fixing notices through the specified document number.')
+@click.option('--breakout',
+              help='Break generated regulation out into separate section files.')
 def apply_through(cfr_title, cfr_part, start=None, through=None,
                   fix_notices=False, skip_fix_notices=[],
-                  skip_fix_notices_through=None):
+                  skip_fix_notices_through=None, breakout=False):
     # Get list of notices that apply to this reg
     # Look for locally available notices
     regml_notice_files = find_all(cfr_part, is_notice=True)
@@ -771,7 +773,7 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
         file_name = os.path.join(notice_file)
         with open(file_name, 'r') as f:
             notice_xml = f.read()
-        parser = etree.XMLParser(huge_tree=True)
+        parser = etree.XMLParser(huge_tree=True, remove_blank_text=True)
 
         try:
             xml_tree = etree.fromstring(notice_xml, parser)
@@ -967,7 +969,7 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
 
         print("[{}] Writing regulation to {}".format(kk, new_path))
 
-        save_regulation(new_xml_tree, new_path, breakout=True)
+        save_regulation(new_xml_tree, new_path, breakout=breakout)
         prev_tree = new_xml_tree
         kk += 1
 

--- a/regml.py
+++ b/regml.py
@@ -488,6 +488,33 @@ def fix_analysis(file, always_save=False):
         print("Canceling analysis fixes - changes have not been saved.")
 
 
+@cli.command('fix-citations')
+@click.argument('file')
+@click.option('--always-fix', is_flag=True)
+def fix_citations(file, always_fix=False):
+    """Checks and fixes the citations in a notice RegML file"""
+    file = find_file(file, is_notice=True)
+    with open(file, 'r') as f:
+        reg_xml = f.read()
+    parser = etree.XMLParser(huge_tree=True, remove_blank_text=True, remove_comments=True)
+    xml_tree = etree.fromstring(reg_xml, parser)
+
+    validator = get_validator(xml_tree)
+    validator.fix_omitted_cites(xml_tree, file, always_fix)
+
+@cli.command('headerize-interps')
+@click.argument('file')
+def headerize_interps(file):
+
+    file = find_file(file, is_notice=True)
+    with open(file, 'r') as f:
+        reg_xml = f.read()
+    parser = etree.XMLParser(huge_tree=True, remove_blank_text=True, remove_comments=True)
+    xml_tree = etree.fromstring(reg_xml, parser)
+
+    validator = get_validator(xml_tree)
+    validator.headerize_interps(xml_tree, file)
+
 # Validate the given regulation file (or files) and generate the JSON
 # output expected by regulations-core and regulations-site if the RegML
 # validates.
@@ -961,35 +988,13 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
         # Add in any new analysis
         new_xml_tree = process_analysis(new_xml_tree, notice_xml)
 
-        # Write the new xml tree
-        new_xml_string = etree.tostring(new_xml_tree,
-                                        pretty_print=True,
-                                        xml_declaration=True,
-                                        encoding='UTF-8')
-<<<<<<< HEAD
         new_path = os.path.join(
             os.path.dirname(regulation_file),
             os.path.basename(notice_file))
-        with open(new_path, 'w') as f:
-            print("[{}] Writing regulation to {}".format(kk, new_path))
-            f.write(new_xml_string)
-=======
-        if doc_counts[notice.document_number] == 1:
-            new_path = os.path.join(
-                os.path.dirname(regulation_file),
-                os.path.basename(notice_file))
-        elif doc_counts[notice.document_number] > 1:
-            new_path = os.path.join(
-                os.path.dirname(regulation_file),
-                notice.document_number + '_' + notice.effective_date.strftime('%Y%m%d') + '.xml')
 
-        #with open(new_path, 'w') as f:
-        print("[{}] Writing regulation to {}".format(kk + 1, new_path))
+        print("[{}] Writing regulation to {}".format(kk, new_path))
 
         save_regulation(new_xml_tree, new_path, breakout=True)
-            #f.write(new_xml_string)
->>>>>>> 713eca3... breaking out the regulation files into separate section files that are then xincluded
-
         prev_tree = new_xml_tree
         kk += 1
 

--- a/regml.py
+++ b/regml.py
@@ -31,7 +31,8 @@ from regulation.tree import (
     build_paragraph_marker_layer,
     build_reg_tree,
     build_terms_layer,
-    build_toc_layer
+    build_toc_layer,
+    save_regulation
 )
 from regulation.changes import (
     process_changes,
@@ -873,9 +874,10 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
     print("Opening initial version {}".format(reg_path))
     regulation_file = find_file(reg_path)
     with open(regulation_file, 'r') as f:
-        left_reg_xml = f.read()
-    parser = etree.XMLParser(huge_tree=True)
-    left_xml_tree = etree.fromstring(left_reg_xml, parser)
+        parser = etree.XMLParser(huge_tree=True, remove_blank_text=True)
+        left_xml_tree = etree.parse(f, parser)
+        left_xml_tree.xinclude()
+        left_xml_tree = left_xml_tree.getroot()
 
     kk = 1
     prev_tree = left_xml_tree
@@ -964,12 +966,29 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
                                         pretty_print=True,
                                         xml_declaration=True,
                                         encoding='UTF-8')
+<<<<<<< HEAD
         new_path = os.path.join(
             os.path.dirname(regulation_file),
             os.path.basename(notice_file))
         with open(new_path, 'w') as f:
             print("[{}] Writing regulation to {}".format(kk, new_path))
             f.write(new_xml_string)
+=======
+        if doc_counts[notice.document_number] == 1:
+            new_path = os.path.join(
+                os.path.dirname(regulation_file),
+                os.path.basename(notice_file))
+        elif doc_counts[notice.document_number] > 1:
+            new_path = os.path.join(
+                os.path.dirname(regulation_file),
+                notice.document_number + '_' + notice.effective_date.strftime('%Y%m%d') + '.xml')
+
+        #with open(new_path, 'w') as f:
+        print("[{}] Writing regulation to {}".format(kk + 1, new_path))
+
+        save_regulation(new_xml_tree, new_path, breakout=True)
+            #f.write(new_xml_string)
+>>>>>>> 713eca3... breaking out the regulation files into separate section files that are then xincluded
 
         prev_tree = new_xml_tree
         kk += 1

--- a/regml.py
+++ b/regml.py
@@ -488,33 +488,6 @@ def fix_analysis(file, always_save=False):
         print("Canceling analysis fixes - changes have not been saved.")
 
 
-@cli.command('fix-citations')
-@click.argument('file')
-@click.option('--always-fix', is_flag=True)
-def fix_citations(file, always_fix=False):
-    """Checks and fixes the citations in a notice RegML file"""
-    file = find_file(file, is_notice=True)
-    with open(file, 'r') as f:
-        reg_xml = f.read()
-    parser = etree.XMLParser(huge_tree=True, remove_blank_text=True, remove_comments=True)
-    xml_tree = etree.fromstring(reg_xml, parser)
-
-    validator = get_validator(xml_tree)
-    validator.fix_omitted_cites(xml_tree, file, always_fix)
-
-@cli.command('headerize-interps')
-@click.argument('file')
-def headerize_interps(file):
-
-    file = find_file(file, is_notice=True)
-    with open(file, 'r') as f:
-        reg_xml = f.read()
-    parser = etree.XMLParser(huge_tree=True, remove_blank_text=True, remove_comments=True)
-    xml_tree = etree.fromstring(reg_xml, parser)
-
-    validator = get_validator(xml_tree)
-    validator.headerize_interps(xml_tree, file)
-
 # Validate the given regulation file (or files) and generate the JSON
 # output expected by regulations-core and regulations-site if the RegML
 # validates.

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -1198,13 +1198,10 @@ def save_regulation(tree, filename, breakout=False):
         if not os.path.exists(notice_dir):
             os.mkdir(notice_dir)
 
-        #print([section.get('label') for section in all_sections])
-
         for section in all_sections:
             parent = section.getparent()
             section_file = os.path.join(notice_dir, section.get('label') + '.xml')
             with open(section_file, 'w') as f:
-                print('Saving section {} to {}'.format(section.get('label'), section_file))
                 f.write(etree.tostring(section, encoding='utf-8', pretty_print='true', xml_declaration='true'))
             include_element = etree.Element('{http://www.w3.org/2003/XInclude}include', {'href': section_file})
             parent.replace(section, include_element)

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -1181,18 +1181,23 @@ def save_regulation(tree, filename, breakout=False):
         all_sections = [section for section in (sections + appendix_sections + interp_sections) if section.get('label') is not None]
 
         root, notice_file = os.path.split(os.path.abspath(filename))
+        cur_dir = os.path.abspath(os.curdir)
         notice_dir = os.path.join(root, document_number)
+        os.chdir(notice_dir)
+
         if not os.path.exists(notice_dir):
             os.mkdir(notice_dir)
 
         for section in all_sections:
             parent = section.getparent()
-            section_file = os.path.join(notice_dir, section.get('label') + '.xml')
+            section_file = section.get('label') + '.xml'
             with open(section_file, 'w') as f:
                 f.write(etree.tostring(section, encoding='utf-8', pretty_print='true', xml_declaration='true'))
-            include_element = etree.Element('{http://www.w3.org/2003/XInclude}include', {'href': section_file})
+            include_element = etree.Element('{http://www.w3.org/2003/XInclude}include',
+                                            {'href': document_number + '/' + section_file})
             parent.replace(section, include_element)
 
+        os.chdir(cur_dir)
+
     with open(filename, 'w') as f:
-        print('Saving tree to {}'.format(filename))
         f.write(etree.tostring(tree_copy, encoding='utf-8', pretty_print=True, xml_declaration=True))

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -801,19 +801,6 @@ def build_toc_layer(root):
             toc_entry = {'index': target, 'title': subject}
             toc_dict[label].append(toc_entry)
 
-        # Build subpart sections
-        for subpart in toc.findall('{eregs}tocSubpartEntry'):
-            target = subpart.get('target', None)
-            subject = subpart.find('{eregs}subpartTitle').text
-            letter = subpart.find('{eregs}subpartLetter').text
-            part = root.find('.//{eregs}part').get('label')
-            if target:
-                target = target.split('-')
-            else:
-                target = [part, 'Subpart', letter]
-            toc_entry = {'index': target, 'title': subject}
-            toc_dict[label].append(toc_entry)
-
     return toc_dict
 
 


### PR DESCRIPTION
This PR changes the way that the `apply-through` command saves the compiled regulation notice. Previously, the entire compiled notice was saved in a single file, but for large notices, this causes problems when trying to view diffs on Github. This PR solves that problem by breaking each section out into its own file, so that e.g. `1005-1` becomes `1005-1.xml` in a subdirectory of `regulations-xml/regulation/1005` that corresponds to the name of the file to which the sections belong. In the above example, the following structure would be generated for the regulation version compiled from notice 2012-1728:

```
regulations-xml/
    regulation/
         2012-1728.xml
         2012-1728/
              1005-1.xml
              ...
```

The root file here, `2012-1728.xml`, now instead contains `xinclude` elements that are processed by lxml at the time that the tree is loaded and which slurp the included sections into the tree structure.

The best way to test this PR is to run `apply-through` on some suitably small reg and observe the changes to the file system. They should be as described above.