### PR TITLE
build the interp layer correctly if there are multiple interpretations sections

### DIFF
--- a/regml.py
+++ b/regml.py
@@ -891,7 +891,7 @@ def apply_through(cfr_title, cfr_part, start=None, through=None,
         notice_file = find_file(file_name, is_notice=True)
         with open(notice_file, 'r') as f:
             notice_string = f.read()
-        parser = etree.XMLParser(huge_tree=True)
+        parser = etree.XMLParser(huge_tree=True, remove_blank_text=True)
 
         notice_xml = etree.fromstring(notice_string, parser)
 

--- a/regulation/tree.py
+++ b/regulation/tree.py
@@ -897,25 +897,26 @@ def build_interp_layer(root):
     """
 
     layer_dict = OrderedDict()
-    interpretations = root.find('.//{eregs}interpretations')
+    interpretations = root.findall('.//{eregs}interpretations')
 
     if interpretations is not None:
-        first_label = interpretations.get('label')
-        first_key = first_label.split('-')[0]
-        layer_dict[first_key] = [{'reference': first_label}]
+        for interpretation in interpretations:
+            first_label = interpretation.get('label')
+            first_key = first_label.split('-')[0]
+            layer_dict[first_key] = [{'reference': first_label}]
 
-        interp_sections = interpretations.findall(
-            './/{eregs}interpSection')
-        interp_paragraphs = interpretations.findall(
-            './/{eregs}interpParagraph')
-        targetted_interps = [i for i in
-            interp_sections + interp_paragraphs
-            if i.get('target') is not None]
+            interp_sections = interpretation.findall(
+                './/{eregs}interpSection')
+            interp_paragraphs = interpretation.findall(
+                './/{eregs}interpParagraph')
+            targetted_interps = [i for i in
+                interp_sections + interp_paragraphs
+                if i.get('target') is not None]
 
-        for interp in targetted_interps:
-            target = interp.get('target')
-            label = interp.get('label')
-            layer_dict[target] = [{'reference': label}]
+            for interp in targetted_interps:
+                target = interp.get('target')
+                label = interp.get('label')
+                layer_dict[target] = [{'reference': label}]
 
     return layer_dict
 


### PR DESCRIPTION
The cause of the missing interp dropdowns in Reg E is because the interp layer builder didn't properly iterate over all the interpretation sections. This PR fixes that.